### PR TITLE
fix: address continual drift in karpenter node pool taints

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -79,4 +79,9 @@ resource "kubernetes_manifest" "node_pool" {
   }
 
   depends_on = [kubernetes_manifest.ec2_node_class]
+
+
+  # Marks the field as managed by Kubernetes to avoid continually detecting drift
+  # https://github.com/hashicorp/terraform-provider-kubernetes/issues/1378
+  computed_fields = ["spec.template.spec.taints"]
 }


### PR DESCRIPTION
## Why

- Kubernetes API modifies taints dynamically.
- `computed_fields` explicitly marks taints as managed by Kubernetes, preventing Terraform from tracking changes while still allowing updates.
- Avoids Terraform drift issues without completely ignoring changes via ignore_changes.
- Ensures Karpenter can dynamically manage taints without Terraform interfering.
- This change addresses the following drift:

```console
 # kubernetes_manifest.node_pool["atomic-low-disk-io"] will be updated in-place
  ~ resource "kubernetes_manifest" "node_pool" {
      ~ object   = {
          ~ spec       = {
              ~ template   = {
                  ~ spec     = {
                      ~ taints        = [
                            {
                                effect    = "NoSchedule"
                                key       = "test.co/atomic-tasks"
                                timeAdded = null
                                value     = "short"
                            },
                          ~ {
                              + value     = (known after apply)
                                # (3 unchanged attributes hidden)
                            },
                        ]
                        # (5 unchanged attributes hidden)
                    }
                    # (1 unchanged attribute hidden)
                }
                # (3 unchanged attributes hidden)
            }
            # (3 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)
    }
```

> [!IMPORTANT]
> The first apply after this change will show resources being added to state before no changes are detected in future runs

## What

* Added `computed_fields` attribute to the `kubernetes_manifest` resource to mark `spec.template.spec.taints` as managed by Kubernetes, which helps avoid continual drift detection.

---

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Usage

```sh
atmos terraform plan eks/karpenter-node-pool -s <stack>
```

## Testing

- [X] Validated with `atmos validate stacks`
- [X] Performed successful `atmos terraform apply` on component

## References

- [Manifest Changes Issue](https://github.com/hashicorp/terraform-provider-kubernetes/issues/1378)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration enhancement for Kubernetes-managed resources that improves drift detection by automatically aligning taint settings with Kubernetes’ control. This update offers a more predictable and stable deployment experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->