### PR TITLE
Migrate README generation to atmos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ aws-assumed-role/
 *.iml
 .direnv
 .envrc
+.cache
+.atmos
 
 # Compiled and auto-generated files
 # Note that the leading "**/" appears necessary for Docker even if not for Git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/`: Terraform component (`main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, `context.tf`). This is the source of truth.
+- `test/`: Go Terratest suite using Atmos fixtures (`component_test.go`, `fixtures/`, `test_suite.yaml`). Tests deploy/destroy real AWS resources.
+- `README.yaml`: Source for the generated `README.md` (via atmos + terraform-docs).
+- `.github/`: CI/CD, Renovate/Dependabot, labels, and automerge settings.
+- `docs/`: Project docs (if any). Keep lightweight and current.
+
+## Build, Test, and Development Commands
+- To install atmos read this docs https://github.com/cloudposse/atmos
+- `atmos docs generate readme`: Regenerate `README.md` from `README.yaml` and terraform source.
+- `atmos docs generate readme-simple`: Regenerate `src/README.md` from `README.yaml` and terraform source.
+- `atmos test run`: Run Terratest suite in `test/` (uses Atmos fixtures; creates and destroys AWS resources).
+- Pre-commit locally: `pre-commit install && pre-commit run -a` (runs `terraform_fmt`, `terraform_docs`, `tflint`).
+- TFLint plugin setup: `tflint --init` (uses `.tflint.hcl`).
+
+## Coding Style & Naming Conventions
+- Indentation: Terraform 2 spaces; YAML/Markdown 2 spaces.
+- Terraform: prefer lower_snake_case for variables/locals; keep resources/data sources descriptive and aligned with Cloud Posse null-label patterns.
+- Lint/format: `terraform fmt -recursive`, TFLint rules per `.tflint.hcl`. Do not commit formatting or lint violations.
+
+## Testing Guidelines
+- Framework: Go Terratest with `github.com/cloudposse/test-helpers` and `atmos` fixtures.
+- Location/naming: put tests in `test/` and name files `*_test.go`. Add scenarios under `test/fixtures/stacks/catalog/usecase/`.
+- Run: `atmos test run`. Ensure AWS credentials are configured; tests may incur AWS costs and will clean up after themselves.
+
+## Commit & Pull Request Guidelines
+- Commits: follow Conventional Commits (e.g., `feat:`, `fix:`, `chore(deps):`, `docs:`). Keep messages concise and scoped.
+- PRs: include a clear description, linked issues, and any behavioral changes. Update `README.yaml` when inputs/outputs change and run `atmos docs generate readme`.
+- CI: ensure pre-commit, TFLint, and tests pass. Avoid unrelated changes in the same PR.
+
+## Security & Configuration Tips
+- Never commit secrets. Configure AWS credentials/role assumption externally; the provider setup in `src/providers.tf` supports role assumption via the `iam_roles` module.
+- Global quotas must be applied in `us-east-1`; place in the `gbl` stack and set `region: us-east-1` in `vars`.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
--include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
-
-all: init readme
-
-test::
-	@echo "🚀 Starting tests..."
-	./test/run.sh
-	@echo "✅ All tests passed."

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 <!-- markdownlint-disable -->
 <a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/aws-eks-karpenter-node-pool/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
-    <p align="right">
-<a href="https://github.com/cloudposse-terraform-components/aws-eks-karpenter-node-pool/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/aws-eks-karpenter-node-pool.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
+
+
+<p align="right"><a href="https://github.com/cloudposse-terraform-components/aws-eks-karpenter-node-pool/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/aws-eks-karpenter-node-pool.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a><a href="https://cloudposse.com/support/"><img src="https://img.shields.io/badge/Get_Support-success.svg?style=for-the-badge" alt="Get Support"/></a>
+
+</p>
 <!-- markdownlint-restore -->
 
 <!--
@@ -49,6 +52,22 @@ Not supported:
   - `userData`
   - `detailedMonitoring`
   - `associatePublicIPAddress`
+
+
+> [!TIP]
+> #### 👽 Use Atmos with Terraform
+> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
+> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
+>
+> <details>
+> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
+> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
+> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
+> </details>
+
+
+
+
 
 ## Usage
 
@@ -162,32 +181,44 @@ components:
                   - "amd64"
 ```
 
-<!-- prettier-ignore-start -->
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+> [!IMPORTANT]
+> In Cloud Posse's examples, we avoid pinning modules to specific versions to prevent discrepancies between the documentation
+> and the latest released versions. However, for your own projects, we strongly advise pinning each module to the exact version
+> you're using. This practice ensures the stability of your infrastructure. Additionally, we recommend implementing a systematic
+> approach for updating versions to avoid unexpected changes.
+
+
+
+
+
+
+
+
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0.0, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1, != 2.21.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1, != 2.21.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 
 ## Resources
 
@@ -201,40 +232,40 @@ components:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
 | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
-| <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
+| <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br/>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
 | <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
 | <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
-| <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
+| <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br/>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
 | <a name="input_kube_exec_auth_role_arn"></a> [kube\_exec\_auth\_role\_arn](#input\_kube\_exec\_auth\_role\_arn) | The role ARN for `aws eks get-token` to use | `string` | `""` | no |
 | <a name="input_kube_exec_auth_role_arn_enabled"></a> [kube\_exec\_auth\_role\_arn\_enabled](#input\_kube\_exec\_auth\_role\_arn\_enabled) | If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token` | `bool` | `true` | no |
-| <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes config file.<br>If supplied, `kubeconfig_context_format` will be ignored. | `string` | `""` | no |
-| <a name="input_kubeconfig_context_format"></a> [kubeconfig\_context\_format](#input\_kubeconfig\_context\_format) | A format string to use for creating the `kubectl` context name when<br>`kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.<br>Must include a single `%s` which will be replaced with the cluster name. | `string` | `""` | no |
+| <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes config file.<br/>If supplied, `kubeconfig_context_format` will be ignored. | `string` | `""` | no |
+| <a name="input_kubeconfig_context_format"></a> [kubeconfig\_context\_format](#input\_kubeconfig\_context\_format) | A format string to use for creating the `kubectl` context name when<br/>`kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.<br/>Must include a single `%s` which will be replaced with the cluster name. | `string` | `""` | no |
 | <a name="input_kubeconfig_exec_auth_api_version"></a> [kubeconfig\_exec\_auth\_api\_version](#input\_kubeconfig\_exec\_auth\_api\_version) | The Kubernetes API version of the credentials returned by the `exec` auth plugin | `string` | `"client.authentication.k8s.io/v1beta1"` | no |
 | <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true` | `string` | `""` | no |
 | <a name="input_kubeconfig_file_enabled"></a> [kubeconfig\_file\_enabled](#input\_kubeconfig\_file\_enabled) | If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster | `bool` | `false` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | Configuration for node pools. See code for details. | <pre>map(object({<br>    # The name of the Karpenter provisioner. The map key is used if this is not set.<br>    name = optional(string)<br>    # Whether to place EC2 instances launched by Karpenter into VPC private subnets. Set it to `false` to use public subnets.<br>    private_subnets_enabled = bool<br>    # The Disruption spec controls how Karpenter scales down the node group.<br>    # See the example (sadly not the specific `spec.disruption` documentation) at https://karpenter.sh/docs/concepts/nodepools/ for details<br>    disruption = optional(object({<br>      # Describes which types of Nodes Karpenter should consider for consolidation.<br>      # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or<br>      # replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost.<br>      # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods.<br>      consolidation_policy = optional(string, "WhenUnderutilized")<br><br>      # The amount of time Karpenter should wait after discovering a consolidation decision (`go` duration string, s, m, or h).<br>      # This value can currently (v0.36.0) only be set when the consolidationPolicy is 'WhenEmpty'.<br>      # You can choose to disable consolidation entirely by setting the string value 'Never' here.<br>      # Earlier versions of Karpenter called this field `ttl_seconds_after_empty`.<br>      consolidate_after = optional(string)<br><br>      # The amount of time a Node can live on the cluster before being removed (`go` duration string, s, m, or h).<br>      # You can choose to disable expiration entirely by setting the string value 'Never' here.<br>      # This module sets a default of 336 hours (14 days), while the Karpenter default is 720 hours (30 days).<br>      # Note that Karpenter calls this field "expiresAfter", and earlier versions called it `ttl_seconds_until_expired`,<br>      # but we call it "max_instance_lifetime" to match the corresponding field in EC2 Auto Scaling Groups.<br>      max_instance_lifetime = optional(string, "336h")<br><br>      # Budgets control the the maximum number of NodeClaims owned by this NodePool that can be terminating at once.<br>      # See https://karpenter.sh/docs/concepts/disruption/#disruption-budgets for details.<br>      # A percentage is the percentage of the total number of active, ready nodes not being deleted, rounded up.<br>      # If there are multiple active budgets, Karpenter uses the most restrictive value.<br>      # If left undefined, this will default to one budget with a value of nodes: 10%.<br>      # Note that budgets do not prevent or limit involuntary terminations.<br>      # Example:<br>      #   On Weekdays during business hours, don't do any deprovisioning.<br>      #     budgets = {<br>      #       schedule = "0 9 * * mon-fri"<br>      #       duration = 8h<br>      #       nodes    = "0"<br>      #     }<br>      budgets = optional(list(object({<br>        # The schedule specifies when a budget begins being active, using extended cronjob syntax.<br>        # See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax for syntax details.<br>        # Timezones are not supported. This field is required if Duration is set.<br>        schedule = optional(string)<br>        # Duration determines how long a Budget is active after each Scheduled start.<br>        # If omitted, the budget is always active. This is required if Schedule is set.<br>        # Must be a whole number of minutes and hours, as cron does not work in seconds,<br>        # but since Go's `duration.String()` always adds a "0s" at the end, that is allowed.<br>        duration = optional(string)<br>        # The percentage or number of nodes that Karpenter can scale down during the budget.<br>        nodes = string<br>      })), [])<br>    }), {})<br>    # Karpenter provisioner total CPU limit for all pods running on the EC2 instances launched by Karpenter<br>    total_cpu_limit = string<br>    # Karpenter provisioner total memory limit for all pods running on the EC2 instances launched by Karpenter<br>    total_memory_limit = string<br>    # Set a weight for this node pool.<br>    # See https://karpenter.sh/docs/concepts/scheduling/#weighted-nodepools<br>    weight      = optional(number, 50)<br>    labels      = optional(map(string))<br>    annotations = optional(map(string))<br>    # Karpenter provisioner taints configuration. See https://aws.github.io/aws-eks-best-practices/karpenter/#create-provisioners-that-are-mutually-exclusive for more details<br>    taints = optional(list(object({<br>      key    = string<br>      effect = string<br>      value  = optional(string)<br>    })))<br>    startup_taints = optional(list(object({<br>      key    = string<br>      effect = string<br>      value  = optional(string)<br>    })))<br>    # Karpenter node metadata options. See https://karpenter.sh/docs/concepts/nodeclasses/#specmetadataoptions for more details<br>    metadata_options = optional(object({<br>      httpEndpoint            = optional(string, "enabled")<br>      httpProtocolIPv6        = optional(string, "disabled")<br>      httpPutResponseHopLimit = optional(number, 2)<br>      # httpTokens can be either "required" or "optional"<br>      httpTokens = optional(string, "required")<br>    }), {})<br>    # The AMI used by Karpenter provisioner when provisioning nodes. Based on the value set for amiFamily, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)<br>    ami_family = string<br>    # Karpenter nodes block device mappings. Controls the Elastic Block Storage volumes that Karpenter attaches to provisioned nodes.<br>    # Karpenter uses default block device mappings for the AMI Family specified.<br>    # For example, the Bottlerocket AMI Family defaults with two block device mappings,<br>    # and normally you only want to scale `/dev/xvdb` where Containers and there storage are stored.<br>    # Most other AMIs only have one device mapping at `/dev/xvda`.<br>    # See https://karpenter.sh/docs/concepts/nodeclasses/#specblockdevicemappings for more details<br>    block_device_mappings = list(object({<br>      deviceName = string<br>      ebs = optional(object({<br>        volumeSize          = string<br>        volumeType          = string<br>        deleteOnTermination = optional(bool, true)<br>        encrypted           = optional(bool, true)<br>        iops                = optional(number)<br>        kmsKeyID            = optional(string, "alias/aws/ebs")<br>        snapshotID          = optional(string)<br>        throughput          = optional(number)<br>      }))<br>    }))<br>    # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture, and capacity type (such as AWS spot or on-demand). See https://karpenter.sh/v0.18.0/provisioner/#specrequirements for more details<br>    requirements = list(object({<br>      key      = string<br>      operator = string<br>      # Operators like "Exists" and "DoesNotExist" do not require a value<br>      values = optional(list(string))<br>    }))<br>    # Any values for spec.template.spec.kubelet allowed by Karpenter.<br>    # Not fully specified, because they are subject to change.<br>    # See:<br>    #   https://karpenter.sh/docs/concepts/nodepools/#spectemplatespeckubelet<br>    #   https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/<br>    kubelet = optional(any, {})<br>  }))</pre> | n/a | yes |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | Configuration for node pools. See code for details. | <pre>map(object({<br/>    # The name of the Karpenter provisioner. The map key is used if this is not set.<br/>    name = optional(string)<br/>    # Whether to place EC2 instances launched by Karpenter into VPC private subnets. Set it to `false` to use public subnets.<br/>    private_subnets_enabled = bool<br/>    # The Disruption spec controls how Karpenter scales down the node group.<br/>    # See the example (sadly not the specific `spec.disruption` documentation) at https://karpenter.sh/docs/concepts/nodepools/ for details<br/>    disruption = optional(object({<br/>      # Describes which types of Nodes Karpenter should consider for consolidation.<br/>      # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or<br/>      # replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost.<br/>      # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods.<br/>      consolidation_policy = optional(string, "WhenUnderutilized")<br/><br/>      # The amount of time Karpenter should wait after discovering a consolidation decision (`go` duration string, s, m, or h).<br/>      # This value can currently (v0.36.0) only be set when the consolidationPolicy is 'WhenEmpty'.<br/>      # You can choose to disable consolidation entirely by setting the string value 'Never' here.<br/>      # Earlier versions of Karpenter called this field `ttl_seconds_after_empty`.<br/>      consolidate_after = optional(string)<br/><br/>      # The amount of time a Node can live on the cluster before being removed (`go` duration string, s, m, or h).<br/>      # You can choose to disable expiration entirely by setting the string value 'Never' here.<br/>      # This module sets a default of 336 hours (14 days), while the Karpenter default is 720 hours (30 days).<br/>      # Note that Karpenter calls this field "expiresAfter", and earlier versions called it `ttl_seconds_until_expired`,<br/>      # but we call it "max_instance_lifetime" to match the corresponding field in EC2 Auto Scaling Groups.<br/>      max_instance_lifetime = optional(string, "336h")<br/><br/>      # Budgets control the the maximum number of NodeClaims owned by this NodePool that can be terminating at once.<br/>      # See https://karpenter.sh/docs/concepts/disruption/#disruption-budgets for details.<br/>      # A percentage is the percentage of the total number of active, ready nodes not being deleted, rounded up.<br/>      # If there are multiple active budgets, Karpenter uses the most restrictive value.<br/>      # If left undefined, this will default to one budget with a value of nodes: 10%.<br/>      # Note that budgets do not prevent or limit involuntary terminations.<br/>      # Example:<br/>      #   On Weekdays during business hours, don't do any deprovisioning.<br/>      #     budgets = {<br/>      #       schedule = "0 9 * * mon-fri"<br/>      #       duration = 8h<br/>      #       nodes    = "0"<br/>      #     }<br/>      budgets = optional(list(object({<br/>        # The schedule specifies when a budget begins being active, using extended cronjob syntax.<br/>        # See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax for syntax details.<br/>        # Timezones are not supported. This field is required if Duration is set.<br/>        schedule = optional(string)<br/>        # Duration determines how long a Budget is active after each Scheduled start.<br/>        # If omitted, the budget is always active. This is required if Schedule is set.<br/>        # Must be a whole number of minutes and hours, as cron does not work in seconds,<br/>        # but since Go's `duration.String()` always adds a "0s" at the end, that is allowed.<br/>        duration = optional(string)<br/>        # The percentage or number of nodes that Karpenter can scale down during the budget.<br/>        nodes = string<br/>        # Reasons can be one of Drifted, Underutilized, or Empty<br/>        # If omitted, it’s assumed that the budget applies to all reasons.<br/>        # See https://karpenter.sh/v1.1/concepts/disruption/#reasons<br/>        reasons = optional(list(string))<br/>      })), [])<br/>    }), {})<br/>    # Karpenter provisioner total CPU limit for all pods running on the EC2 instances launched by Karpenter<br/>    total_cpu_limit = string<br/>    # Karpenter provisioner total memory limit for all pods running on the EC2 instances launched by Karpenter<br/>    total_memory_limit = string<br/>    # Set a weight for this node pool.<br/>    # See https://karpenter.sh/docs/concepts/scheduling/#weighted-nodepools<br/>    weight      = optional(number, 50)<br/>    labels      = optional(map(string))<br/>    annotations = optional(map(string))<br/>    # Karpenter provisioner taints configuration. See https://aws.github.io/aws-eks-best-practices/karpenter/#create-provisioners-that-are-mutually-exclusive for more details<br/>    taints = optional(list(object({<br/>      key    = string<br/>      effect = string<br/>      value  = optional(string)<br/>    })))<br/>    startup_taints = optional(list(object({<br/>      key    = string<br/>      effect = string<br/>      value  = optional(string)<br/>    })))<br/>    # Karpenter node metadata options. See https://karpenter.sh/docs/concepts/nodeclasses/#specmetadataoptions for more details<br/>    metadata_options = optional(object({<br/>      httpEndpoint            = optional(string, "enabled")<br/>      httpProtocolIPv6        = optional(string, "disabled")<br/>      httpPutResponseHopLimit = optional(number, 2)<br/>      # httpTokens can be either "required" or "optional"<br/>      httpTokens = optional(string, "required")<br/>    }), {})<br/>    # ami_family dictates the default bootstrapping logic.<br/>    # It is only required if you do not specify amiSelectorTerms.alias<br/>    ami_family = optional(string, null)<br/>    # Selectors for the AMI used by Karpenter provisioner when provisioning nodes.<br/>    # Usually use { alias = "<family>@latest" } but version can be pinned instead of "latest".<br/>    # Based on the ami_selector_terms, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)<br/>    ami_selector_terms = list(any)<br/>    # Karpenter nodes block device mappings. Controls the Elastic Block Storage volumes that Karpenter attaches to provisioned nodes.<br/>    # Karpenter uses default block device mappings for the AMI Family specified.<br/>    # For example, the Bottlerocket AMI Family defaults with two block device mappings,<br/>    # and normally you only want to scale `/dev/xvdb` where Containers and there storage are stored.<br/>    # Most other AMIs only have one device mapping at `/dev/xvda`.<br/>    # See https://karpenter.sh/docs/concepts/nodeclasses/#specblockdevicemappings for more details<br/>    block_device_mappings = list(object({<br/>      deviceName = string<br/>      ebs = optional(object({<br/>        volumeSize          = string<br/>        volumeType          = string<br/>        deleteOnTermination = optional(bool, true)<br/>        encrypted           = optional(bool, true)<br/>        iops                = optional(number)<br/>        kmsKeyID            = optional(string, "alias/aws/ebs")<br/>        snapshotID          = optional(string)<br/>        throughput          = optional(number)<br/>      }))<br/>    }))<br/>    # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture, and capacity type (such as AWS spot or on-demand). See https://karpenter.sh/v0.18.0/provisioner/#specrequirements for more details<br/>    requirements = list(object({<br/>      key      = string<br/>      operator = string<br/>      # Operators like "Exists" and "DoesNotExist" do not require a value<br/>      values = optional(list(string))<br/>    }))<br/>    # Any values for spec.template.spec.kubelet allowed by Karpenter.<br/>    # Not fully specified, because they are subject to change.<br/>    # See:<br/>    #   https://karpenter.sh/docs/concepts/nodepools/#spectemplatespeckubelet<br/>    #   https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/<br/>    kubelet = optional(any, {})<br/>  }))</pre> | n/a | yes |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 
 ## Outputs
@@ -243,35 +274,7 @@ components:
 |------|-------------|
 | <a name="output_ec2_node_classes"></a> [ec2\_node\_classes](#output\_ec2\_node\_classes) | Deployed Karpenter EC2NodeClass |
 | <a name="output_node_pools"></a> [node\_pools](#output\_node\_pools) | Deployed Karpenter NodePool |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- prettier-ignore-end -->
-
-## References
-
-- https://karpenter.sh
-- https://aws.github.io/aws-eks-best-practices/karpenter
-- https://karpenter.sh/docs/concepts/nodepools
-- https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler
-- https://github.com/aws/karpenter
-- https://ec2spotworkshops.com/karpenter.html
-- https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/
-
-
-> [!TIP]
-> #### 👽 Use Atmos with Terraform
-> Cloud Posse uses [`atmos`](https://atmos.tools) to easily orchestrate multiple environments using Terraform. <br/>
-> Works with [Github Actions](https://atmos.tools/integrations/github-actions/), [Atlantis](https://atmos.tools/integrations/atlantis), or [Spacelift](https://atmos.tools/integrations/spacelift).
->
-> <details>
-> <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
-> <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
-> <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
-> </detalis>
-
-
-
-
-
+<!-- markdownlint-restore -->
 
 
 
@@ -284,6 +287,20 @@ Check out these related projects.
 
 - [Cloud Posse Terraform Modules](https://docs.cloudposse.com/modules/) - Our collection of reusable Terraform modules used by our reference architectures.
 - [Atmos](https://atmos.tools) - Atmos is like docker-compose but for your infrastructure
+
+
+## References
+
+For additional context, refer to some of these links.
+
+- [https://karpenter.sh](https://karpenter.sh) - 
+- [https://aws.github.io/aws-eks-best-practices/karpenter](https://aws.github.io/aws-eks-best-practices/karpenter) - 
+- [https://karpenter.sh/docs/concepts/nodepools](https://karpenter.sh/docs/concepts/nodepools) - 
+- [https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler](https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler) - 
+- [https://github.com/aws/karpenter](https://github.com/aws/karpenter) - 
+- [https://ec2spotworkshops.com/karpenter.html](https://ec2spotworkshops.com/karpenter.html) - 
+- [https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/](https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/) - 
+
 
 
 > [!TIP]
@@ -349,6 +366,38 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
  6. Submit a **Pull Request** so that we can review your changes
 
 **NOTE:** Be sure to merge the latest changes from "upstream" before making a pull request!
+
+
+## Running Terraform Tests
+
+We use [Atmos](https://atmos.tools) to streamline how Terraform tests are run. It centralizes configuration and wraps common test workflows with easy-to-use commands.
+
+All tests are located in the [`test/`](test) folder.
+
+Under the hood, tests are powered by Terratest together with our internal [Test Helpers](https://github.com/cloudposse/test-helpers) library, providing robust infrastructure validation.
+
+Setup dependencies:
+- Install Atmos ([installation guide](https://atmos.tools/install/))
+- Install Go [1.24+ or newer](https://go.dev/doc/install)
+- Install Terraform or OpenTofu
+
+To run tests:
+
+- Run all tests:  
+  ```sh
+  atmos test run
+  ```
+- Clean up test artifacts:  
+  ```sh
+  atmos test clean
+  ```
+- Explore additional test options:  
+  ```sh
+  atmos test --help
+  ```
+The configuration for test commands is centrally managed. To review what's being imported, see the [`atmos.yaml`](https://raw.githubusercontent.com/cloudposse/.github/refs/heads/main/.github/atmos/terraform-module.yaml) file.
+
+Learn more about our [automated testing in our documentation](https://docs.cloudposse.com/community/contribute/automated-testing/) or implementing [custom commands](https://atmos.tools/core-concepts/custom-commands/) with atmos.
 
 ### 🌎 Slack Community
 

--- a/README.yaml
+++ b/README.yaml
@@ -25,9 +25,7 @@ description: |-
     - `userData`
     - `detailedMonitoring`
     - `associatePublicIPAddress`
-
-  ## Usage
-
+usage: |-
   **Stack Level**: Regional
 
   If provisioning more than one NodePool, it is
@@ -137,100 +135,28 @@ description: |-
                   values:
                     - "amd64"
   ```
-
-  <!-- prettier-ignore-start -->
-  <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-  ## Requirements
-
-  | Name | Version |
-  |------|---------|
-  | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-  | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
-  | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.0 |
-  | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1, != 2.21.0 |
-
-  ## Providers
-
-  | Name | Version |
-  |------|---------|
-  | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
-  | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1, != 2.21.0 |
-
-  ## Modules
-
-  | Name | Source | Version |
-  |------|--------|---------|
-  | <a name="module_eks"></a> [eks](#module\_eks) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-  | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../../account-map/modules/iam-roles | n/a |
-  | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-  | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/stack-config/yaml//modules/remote-state | 1.5.0 |
-
-  ## Resources
-
-  | Name | Type |
-  |------|------|
-  | [kubernetes_manifest.ec2_node_class](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-  | [kubernetes_manifest.node_pool](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
-  | [aws_eks_cluster_auth.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
-
-  ## Inputs
-
-  | Name | Description | Type | Default | Required |
-  |------|-------------|------|---------|:--------:|
-  | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br>This is for some rare cases where resources want additional configuration of tags<br>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-  | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br>in the order they appear in the list. New attributes are appended to the<br>end of the list. The elements of the list are joined by the `delimiter`<br>and treated as a single ID element. | `list(string)` | `[]` | no |
-  | <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "descriptor_formats": {},<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "labels_as_tags": [<br>    "unset"<br>  ],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {},<br>  "tenant": null<br>}</pre> | no |
-  | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-  | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br>Map of maps. Keys are names of descriptors. Values are maps of the form<br>`{<br>   format = string<br>   labels = list(string)<br>}`<br>(Type is `any` so the map values can later be enhanced to provide additional options.)<br>`format` is a Terraform format string to be passed to the `format()` function.<br>`labels` is a list of labels, in order, to pass to `format()` function.<br>Label values will be normalized before being passed to `format()` so they will be<br>identical to how they appear in `id`.<br>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-  | <a name="input_eks_component_name"></a> [eks\_component\_name](#input\_eks\_component\_name) | The name of the eks component | `string` | `"eks/cluster"` | no |
-  | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-  | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-  | <a name="input_helm_manifest_experiment_enabled"></a> [helm\_manifest\_experiment\_enabled](#input\_helm\_manifest\_experiment\_enabled) | Enable storing of the rendered manifest for helm\_release so the full diff of what is changing can been seen in the plan | `bool` | `false` | no |
-  | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
-  | <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
-  | <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
-  | <a name="input_kube_data_auth_enabled"></a> [kube\_data\_auth\_enabled](#input\_kube\_data\_auth\_enabled) | If `true`, use an `aws_eks_cluster_auth` data source to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled` or `kube_exec_auth_enabled`. | `bool` | `false` | no |
-  | <a name="input_kube_exec_auth_aws_profile"></a> [kube\_exec\_auth\_aws\_profile](#input\_kube\_exec\_auth\_aws\_profile) | The AWS config profile for `aws eks get-token` to use | `string` | `""` | no |
-  | <a name="input_kube_exec_auth_aws_profile_enabled"></a> [kube\_exec\_auth\_aws\_profile\_enabled](#input\_kube\_exec\_auth\_aws\_profile\_enabled) | If `true`, pass `kube_exec_auth_aws_profile` as the `profile` to `aws eks get-token` | `bool` | `false` | no |
-  | <a name="input_kube_exec_auth_enabled"></a> [kube\_exec\_auth\_enabled](#input\_kube\_exec\_auth\_enabled) | If `true`, use the Kubernetes provider `exec` feature to execute `aws eks get-token` to authenticate to the EKS cluster.<br>Disabled by `kubeconfig_file_enabled`, overrides `kube_data_auth_enabled`. | `bool` | `true` | no |
-  | <a name="input_kube_exec_auth_role_arn"></a> [kube\_exec\_auth\_role\_arn](#input\_kube\_exec\_auth\_role\_arn) | The role ARN for `aws eks get-token` to use | `string` | `""` | no |
-  | <a name="input_kube_exec_auth_role_arn_enabled"></a> [kube\_exec\_auth\_role\_arn\_enabled](#input\_kube\_exec\_auth\_role\_arn\_enabled) | If `true`, pass `kube_exec_auth_role_arn` as the role ARN to `aws eks get-token` | `bool` | `true` | no |
-  | <a name="input_kubeconfig_context"></a> [kubeconfig\_context](#input\_kubeconfig\_context) | Context to choose from the Kubernetes config file.<br>If supplied, `kubeconfig_context_format` will be ignored. | `string` | `""` | no |
-  | <a name="input_kubeconfig_context_format"></a> [kubeconfig\_context\_format](#input\_kubeconfig\_context\_format) | A format string to use for creating the `kubectl` context name when<br>`kubeconfig_file_enabled` is `true` and `kubeconfig_context` is not supplied.<br>Must include a single `%s` which will be replaced with the cluster name. | `string` | `""` | no |
-  | <a name="input_kubeconfig_exec_auth_api_version"></a> [kubeconfig\_exec\_auth\_api\_version](#input\_kubeconfig\_exec\_auth\_api\_version) | The Kubernetes API version of the credentials returned by the `exec` auth plugin | `string` | `"client.authentication.k8s.io/v1beta1"` | no |
-  | <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | The Kubernetes provider `config_path` setting to use when `kubeconfig_file_enabled` is `true` | `string` | `""` | no |
-  | <a name="input_kubeconfig_file_enabled"></a> [kubeconfig\_file\_enabled](#input\_kubeconfig\_file\_enabled) | If `true`, configure the Kubernetes provider with `kubeconfig_file` and use that kubeconfig file for authenticating to the EKS cluster | `bool` | `false` | no |
-  | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br>Does not affect keys of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
-  | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-  | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br>set as tag values, and output by this module individually.<br>Does not affect values of tags passed in via the `tags` input.<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br>Default value: `lower`. | `string` | `null` | no |
-  | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br>Default is to include all labels.<br>Tags with empty values will not be included in the `tags` output.<br>Set to `[]` to suppress all generated tags.<br>**Notes:**<br>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br>  "default"<br>]</pre> | no |
-  | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br>This is the only ID element not also included as a `tag`.<br>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-  | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-  | <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | Configuration for node pools. See code for details. | <pre>map(object({<br>    # The name of the Karpenter provisioner. The map key is used if this is not set.<br>    name = optional(string)<br>    # Whether to place EC2 instances launched by Karpenter into VPC private subnets. Set it to `false` to use public subnets.<br>    private_subnets_enabled = bool<br>    # The Disruption spec controls how Karpenter scales down the node group.<br>    # See the example (sadly not the specific `spec.disruption` documentation) at https://karpenter.sh/docs/concepts/nodepools/ for details<br>    disruption = optional(object({<br>      # Describes which types of Nodes Karpenter should consider for consolidation.<br>      # If using 'WhenUnderutilized', Karpenter will consider all nodes for consolidation and attempt to remove or<br>      # replace Nodes when it discovers that the Node is underutilized and could be changed to reduce cost.<br>      # If using `WhenEmpty`, Karpenter will only consider nodes for consolidation that contain no workload pods.<br>      consolidation_policy = optional(string, "WhenUnderutilized")<br><br>      # The amount of time Karpenter should wait after discovering a consolidation decision (`go` duration string, s, m, or h).<br>      # This value can currently (v0.36.0) only be set when the consolidationPolicy is 'WhenEmpty'.<br>      # You can choose to disable consolidation entirely by setting the string value 'Never' here.<br>      # Earlier versions of Karpenter called this field `ttl_seconds_after_empty`.<br>      consolidate_after = optional(string)<br><br>      # The amount of time a Node can live on the cluster before being removed (`go` duration string, s, m, or h).<br>      # You can choose to disable expiration entirely by setting the string value 'Never' here.<br>      # This module sets a default of 336 hours (14 days), while the Karpenter default is 720 hours (30 days).<br>      # Note that Karpenter calls this field "expiresAfter", and earlier versions called it `ttl_seconds_until_expired`,<br>      # but we call it "max_instance_lifetime" to match the corresponding field in EC2 Auto Scaling Groups.<br>      max_instance_lifetime = optional(string, "336h")<br><br>      # Budgets control the the maximum number of NodeClaims owned by this NodePool that can be terminating at once.<br>      # See https://karpenter.sh/docs/concepts/disruption/#disruption-budgets for details.<br>      # A percentage is the percentage of the total number of active, ready nodes not being deleted, rounded up.<br>      # If there are multiple active budgets, Karpenter uses the most restrictive value.<br>      # If left undefined, this will default to one budget with a value of nodes: 10%.<br>      # Note that budgets do not prevent or limit involuntary terminations.<br>      # Example:<br>      #   On Weekdays during business hours, don't do any deprovisioning.<br>      #     budgets = {<br>      #       schedule = "0 9 * * mon-fri"<br>      #       duration = 8h<br>      #       nodes    = "0"<br>      #     }<br>      budgets = optional(list(object({<br>        # The schedule specifies when a budget begins being active, using extended cronjob syntax.<br>        # See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax for syntax details.<br>        # Timezones are not supported. This field is required if Duration is set.<br>        schedule = optional(string)<br>        # Duration determines how long a Budget is active after each Scheduled start.<br>        # If omitted, the budget is always active. This is required if Schedule is set.<br>        # Must be a whole number of minutes and hours, as cron does not work in seconds,<br>        # but since Go's `duration.String()` always adds a "0s" at the end, that is allowed.<br>        duration = optional(string)<br>        # The percentage or number of nodes that Karpenter can scale down during the budget.<br>        nodes = string<br>      })), [])<br>    }), {})<br>    # Karpenter provisioner total CPU limit for all pods running on the EC2 instances launched by Karpenter<br>    total_cpu_limit = string<br>    # Karpenter provisioner total memory limit for all pods running on the EC2 instances launched by Karpenter<br>    total_memory_limit = string<br>    # Set a weight for this node pool.<br>    # See https://karpenter.sh/docs/concepts/scheduling/#weighted-nodepools<br>    weight      = optional(number, 50)<br>    labels      = optional(map(string))<br>    annotations = optional(map(string))<br>    # Karpenter provisioner taints configuration. See https://aws.github.io/aws-eks-best-practices/karpenter/#create-provisioners-that-are-mutually-exclusive for more details<br>    taints = optional(list(object({<br>      key    = string<br>      effect = string<br>      value  = optional(string)<br>    })))<br>    startup_taints = optional(list(object({<br>      key    = string<br>      effect = string<br>      value  = optional(string)<br>    })))<br>    # Karpenter node metadata options. See https://karpenter.sh/docs/concepts/nodeclasses/#specmetadataoptions for more details<br>    metadata_options = optional(object({<br>      httpEndpoint            = optional(string, "enabled")<br>      httpProtocolIPv6        = optional(string, "disabled")<br>      httpPutResponseHopLimit = optional(number, 2)<br>      # httpTokens can be either "required" or "optional"<br>      httpTokens = optional(string, "required")<br>    }), {})<br>    # The AMI used by Karpenter provisioner when provisioning nodes. Based on the value set for amiFamily, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)<br>    ami_family = string<br>    # Karpenter nodes block device mappings. Controls the Elastic Block Storage volumes that Karpenter attaches to provisioned nodes.<br>    # Karpenter uses default block device mappings for the AMI Family specified.<br>    # For example, the Bottlerocket AMI Family defaults with two block device mappings,<br>    # and normally you only want to scale `/dev/xvdb` where Containers and there storage are stored.<br>    # Most other AMIs only have one device mapping at `/dev/xvda`.<br>    # See https://karpenter.sh/docs/concepts/nodeclasses/#specblockdevicemappings for more details<br>    block_device_mappings = list(object({<br>      deviceName = string<br>      ebs = optional(object({<br>        volumeSize          = string<br>        volumeType          = string<br>        deleteOnTermination = optional(bool, true)<br>        encrypted           = optional(bool, true)<br>        iops                = optional(number)<br>        kmsKeyID            = optional(string, "alias/aws/ebs")<br>        snapshotID          = optional(string)<br>        throughput          = optional(number)<br>      }))<br>    }))<br>    # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture, and capacity type (such as AWS spot or on-demand). See https://karpenter.sh/v0.18.0/provisioner/#specrequirements for more details<br>    requirements = list(object({<br>      key      = string<br>      operator = string<br>      # Operators like "Exists" and "DoesNotExist" do not require a value<br>      values = optional(list(string))<br>    }))<br>    # Any values for spec.template.spec.kubelet allowed by Karpenter.<br>    # Not fully specified, because they are subject to change.<br>    # See:<br>    #   https://karpenter.sh/docs/concepts/nodepools/#spectemplatespeckubelet<br>    #   https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/<br>    kubelet = optional(any, {})<br>  }))</pre> | n/a | yes |
-  | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-  | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-  | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-  | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-  | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-
-  ## Outputs
-
-  | Name | Description |
-  |------|-------------|
-  | <a name="output_ec2_node_classes"></a> [ec2\_node\_classes](#output\_ec2\_node\_classes) | Deployed Karpenter EC2NodeClass |
-  | <a name="output_node_pools"></a> [node\_pools](#output\_node\_pools) | Deployed Karpenter NodePool |
-  <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-  <!-- prettier-ignore-end -->
-
-  ## References
-
-  - https://karpenter.sh
-  - https://aws.github.io/aws-eks-best-practices/karpenter
-  - https://karpenter.sh/docs/concepts/nodepools
-  - https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler
-  - https://github.com/aws/karpenter
-  - https://ec2spotworkshops.com/karpenter.html
-  - https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/
+references:
+  - name: "https://karpenter.sh"
+    description: ""
+    url: "https://karpenter.sh"
+  - name: "https://aws.github.io/aws-eks-best-practices/karpenter"
+    description: ""
+    url: "https://aws.github.io/aws-eks-best-practices/karpenter"
+  - name: "https://karpenter.sh/docs/concepts/nodepools"
+    description: ""
+    url: "https://karpenter.sh/docs/concepts/nodepools"
+  - name: "https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler"
+    description: ""
+    url: "https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler"
+  - name: "https://github.com/aws/karpenter"
+    description: ""
+    url: "https://github.com/aws/karpenter"
+  - name: "https://ec2spotworkshops.com/karpenter.html"
+    description: ""
+    url: "https://ec2spotworkshops.com/karpenter.html"
+  - name: "https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/"
+    description: ""
+    url: "https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/"
 tags:
   - component/eks/karpenter-node-pool
   - layer/eks

--- a/atmos.yaml
+++ b/atmos.yaml
@@ -1,0 +1,11 @@
+# Atmos Configuration — powered by https://atmos.tools
+#
+# This configuration enables centralized, DRY, and consistent project scaffolding using Atmos.
+#
+# Included features:
+# - Organizational custom commands: https://atmos.tools/core-concepts/custom-commands
+# - Automated README generation: https://atmos.tools/cli/commands/docs/generate
+#
+# Import shared configuration used by all modules
+import:
+  - https://raw.githubusercontent.com/cloudposse-terraform-components/.github/refs/heads/main/.github/atmos/terraform-component.yaml

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ tags:
   - provider/helm
 ---
 
-# Component: `eks/karpenter-node-pool`
+# Component: `eks-karpenter-node-pool`
 
 This component deploys [Karpenter NodePools](https://karpenter.sh/docs/concepts/nodepools/) to an EKS cluster.
 
@@ -30,7 +30,6 @@ Not supported:
   - `userData`
   - `detailedMonitoring`
   - `associatePublicIPAddress`
-
 ## Usage
 
 **Stack Level**: Regional
@@ -143,8 +142,8 @@ components:
                   - "amd64"
 ```
 
-<!-- prettier-ignore-start -->
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -224,17 +223,29 @@ components:
 |------|-------------|
 | <a name="output_ec2_node_classes"></a> [ec2\_node\_classes](#output\_ec2\_node\_classes) | Deployed Karpenter EC2NodeClass |
 | <a name="output_node_pools"></a> [node\_pools](#output\_node\_pools) | Deployed Karpenter NodePool |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
+
+
 
 ## References
 
-- https://karpenter.sh
-- https://aws.github.io/aws-eks-best-practices/karpenter
-- https://karpenter.sh/docs/concepts/nodepools
-- https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler
-- https://github.com/aws/karpenter
-- https://ec2spotworkshops.com/karpenter.html
-- https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/
 
-[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/component)
+- [https://karpenter.sh](https://karpenter.sh) - 
+
+- [https://aws.github.io/aws-eks-best-practices/karpenter](https://aws.github.io/aws-eks-best-practices/karpenter) - 
+
+- [https://karpenter.sh/docs/concepts/nodepools](https://karpenter.sh/docs/concepts/nodepools) - 
+
+- [https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler](https://aws.amazon.com/blogs/aws/introducing-karpenter-an-open-source-high-performance-kubernetes-cluster-autoscaler) - 
+
+- [https://github.com/aws/karpenter](https://github.com/aws/karpenter) - 
+
+- [https://ec2spotworkshops.com/karpenter.html](https://ec2spotworkshops.com/karpenter.html) - 
+
+- [https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/](https://www.eksworkshop.com/docs/autoscaling/compute/karpenter/) - 
+
+
+
+
+[<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-eks-karpenter-node-pool&utm_content=)
+


### PR DESCRIPTION
## what
- Update README.yaml

## why
- Use atmos to generate readme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added comprehensive contributor guide (AGENTS.md) covering workflows, testing, style, and security.
  - Expanded README with Atmos/Terraform usage, testing instructions, version pinning guidance, updated requirements, and reorganized references.
  - Restructured README.yaml with explicit usage and references, improved metadata (tags/categories).
  - Updated component docs and references in src/README.md.

- Chores
  - Added .cache and .atmos to .gitignore.
  - Introduced Atmos configuration (atmos.yaml) to centralize shared settings.
  - Removed legacy Makefile targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->