### PR TITLE
feat: support EKS Auto Mode NodeClass

### DIFF
--- a/src/UPDATING.md
+++ b/src/UPDATING.md
@@ -13,7 +13,7 @@ required.
 
 ### 1. Upgrade the upstream `eks/cluster` component
 
-Starting from (`v1.541.0`)[https://github.com/cloudposse-terraform-components/aws-eks-cluster/releases/tag/v1.541.0] the `eks/cluster` component
+Starting from [`v1.541.0`](https://github.com/cloudposse-terraform-components/aws-eks-cluster/releases/tag/v1.541.0) the `eks/cluster` component
 must expose two new remote-state outputs consumed here:
 
 - `auto_mode_enabled` (`bool`)

--- a/src/UPDATING.md
+++ b/src/UPDATING.md
@@ -1,0 +1,100 @@
+# Updating
+
+## Migrating to EKS Auto Mode
+
+This component now supports provisioning Karpenter `NodePool` and `NodeClass` resources against either:
+
+- **Self-managed Karpenter** (the original behavior) — `karpenter.k8s.aws/v1` API
+- **EKS Auto Mode** — `eks.amazonaws.com/v1` API
+
+The mode is selected automatically from the upstream `eks/cluster` component output `auto_mode_enabled`. No
+variable on this component needs to be flipped to switch modes — but several upstream and stack changes are
+required.
+
+### 1. Upgrade the upstream `eks/cluster` component
+
+Starting from (`v1.541.0`)[https://github.com/cloudposse-terraform-components/aws-eks-cluster/releases/tag/v1.541.0] the `eks/cluster` component
+must expose two new remote-state outputs consumed here:
+
+- `auto_mode_enabled` (`bool`)
+- `auto_mode_node_role_name` (`string`) — the IAM role attached to Auto Mode managed nodes
+
+If you are using `account_map_enabled: false` and passing `var.eks` directly, add the new fields:
+
+```yaml
+components:
+  terraform:
+    eks/karpenter-node-pool:
+      vars:
+        eks:
+          # ... existing fields
+          auto_mode_enabled: true
+          auto_mode_node_role_name: "my-cluster-auto-mode-node"
+```
+
+### 2. Remote-state version bump
+
+`cloudposse/stack-config/yaml//modules/remote-state` is pinned to `2.0.0`. Run `terraform init -upgrade` after
+pulling this change.
+
+### 3. New `utils` provider requirement
+
+`cloudposse/utils >= 2.0.0, < 3.0.0` has been added to `versions.tf`. `terraform init -upgrade` will fetch it.
+
+### 4. Reserved NodePool names
+
+EKS Auto Mode ships built-in NodePools named `general-purpose` and `system`. When `auto_mode_enabled` is true,
+this component will fail a `check` block if any entry in `var.node_pools` resolves to one of those names
+(either via the map key or via `name`). Rename any conflicting pools before upgrading.
+
+### 5. NodePool requirement keys are auto-rewritten
+
+Under Auto Mode, requirement keys with the prefix `karpenter.k8s.aws/` are automatically rewritten to
+`eks.amazonaws.com/` (e.g. `karpenter.k8s.aws/instance-category` → `eks.amazonaws.com/instance-category`).
+Existing `var.node_pools[*].requirements` entries do **not** need to be edited — but be aware that the rendered
+manifest will differ.
+
+### 6. Fields ignored under Auto Mode
+
+Auto Mode `NodeClass` does not accept the EC2-specific fields below. They remain in `var.node_pools` for
+backwards compatibility with self-managed Karpenter and are silently ignored when `auto_mode_enabled` is true:
+
+- `ami_selector_terms`
+- `ami_family`
+- `block_device_mappings`
+- `metadata_options`
+- `detailed_monitoring`
+- `user_data`
+- `tags` (the `AmazonEKSComputePolicy` restricts launch-template tag keys to `eks:*` and
+  `kubernetes.io/cluster/*`, so custom tags from `module.this.tags` are not propagated)
+
+`ami_selector_terms` and `block_device_mappings` are now `optional()` in the variable schema, so node pools
+intended only for Auto Mode can omit them entirely.
+
+### 7. New optional Auto Mode fields
+
+The following optional fields have been added to each entry of `var.node_pools` and apply only when
+`auto_mode_enabled` is true:
+
+| Field                                 | Purpose                                                                    |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| `ephemeral_storage`                   | `{ size, iops, throughput, kmsKeyID }` for the node root volume            |
+| `snat_policy`                         | `"Random"` or `"Disabled"`                                                 |
+| `network_policy`                      | `"DefaultAllow"` or `"DefaultDeny"`                                        |
+| `network_policy_event_logs`           | `"Enabled"` or `"Disabled"`                                                |
+| `advanced_networking`                 | Proxy / public IP / IPv4 prefix configuration                              |
+| `advanced_security`                   | `{ fips }` (US regions only)                                               |
+| `certificate_bundles`                 | Custom CA bundles to trust on the node                                     |
+| `capacity_reservation_selector_terms` | Target on-demand capacity reservations                                     |
+| `pod_subnet_selector_terms`           | Pod-level subnet selection (set together with `pod_security_group_*`)      |
+| `pod_security_group_selector_terms`   | Pod-level SG selection (set together with `pod_subnet_selector_terms`)     |
+
+See `variables.tf` for the full type definitions and the
+[AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html) for value semantics.
+
+### 8. Plan carefully — resources are replaced, not updated
+
+Switching a cluster from self-managed Karpenter to Auto Mode causes the `kubernetes_manifest.ec2_node_class`
+resources to be destroyed and `kubernetes_manifest.auto_mode_node_class` resources to be created in their
+place. Drain workloads off Karpenter-managed nodes before applying, and review the plan output to confirm the
+expected NodeClass kind (`EC2NodeClass` vs. `NodeClass`) and API group.

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -7,11 +7,11 @@
 # with the Karpenter documentation, and to track changes as
 # Karpenter evolves.
 #
-# When eks_auto_mode_enabled is true, we create a simplified NodeClass
+# When auto_mode_enabled is true, we create a simplified NodeClass
 # using the eks.amazonaws.com/v1 API instead of karpenter.k8s.aws/v1.
 # Auto Mode NodeClass does not support EC2-specific fields like
-# role, subnetSelectorTerms, securityGroupSelectorTerms, amiSelectorTerms,
-# metadataOptions, blockDeviceMappings, amiFamily, detailedMonitoring, or userData.
+# amiSelectorTerms, metadataOptions, blockDeviceMappings, amiFamily,
+# detailedMonitoring, or userData.
 
 locals {
   # If you include a field but set it to null, the field will be omitted from the Kubernetes resource,
@@ -78,6 +78,13 @@ resource "kubernetes_manifest" "ec2_node_class" {
 resource "kubernetes_manifest" "auto_mode_node_class" {
   for_each = local.auto_mode_node_pools
 
+  lifecycle {
+    precondition {
+      condition     = module.eks.outputs.auto_mode_node_role_name != null && module.eks.outputs.auto_mode_node_role_name != "deleted"
+      error_message = "EKS Auto Mode requires eks.auto_mode_node_role_name to be set to a valid IAM role name. Ensure the eks/cluster component outputs auto_mode_node_role_name."
+    }
+  }
+
   manifest = {
     apiVersion = local.node_class_api_version
     kind       = local.node_class_kind
@@ -87,20 +94,7 @@ resource "kubernetes_manifest" "auto_mode_node_class" {
     spec = merge(
       {
         # Required fields
-resource "kubernetes_manifest" "auto_mode_node_class" {
-  for_each = local.auto_mode_node_pools
-
-  lifecycle {
-    precondition {
-      condition     = module.eks.outputs.auto_mode_node_role_name != null && module.eks.outputs.auto_mode_node_role_name != "deleted"
-      error_message = "EKS Auto Mode requires eks.auto_mode_node_role_name to be set to a valid IAM role name."
-    }
-  }
-
-  manifest = {
-    role = module.eks.outputs.auto_mode_node_role_name
-  }
-}
+        role = module.eks.outputs.auto_mode_node_role_name
         subnetSelectorTerms = [for id in(each.value.private_subnets_enabled ? local.private_subnet_ids : local.public_subnet_ids) : {
           id = id
         }]
@@ -115,8 +109,8 @@ resource "kubernetes_manifest" "auto_mode_node_class" {
       each.value.snat_policy != null ? { snatPolicy = each.value.snat_policy } : {},
       each.value.network_policy != null ? { networkPolicy = each.value.network_policy } : {},
       each.value.network_policy_event_logs != null ? { networkPolicyEventLogs = each.value.network_policy_event_logs } : {},
-      each.value.advanced_networking != null ? { advancedNetworking = each.value.advanced_networking } : {},
-      each.value.advanced_security != null ? { advancedSecurity = each.value.advanced_security } : {},
+      each.value.advanced_networking != null ? { advancedNetworking = { for k, v in each.value.advanced_networking : k => v if v != null } } : {},
+      each.value.advanced_security != null ? { advancedSecurity = { for k, v in each.value.advanced_security : k => v if v != null } } : {},
       each.value.certificate_bundles != null ? { certificateBundles = each.value.certificate_bundles } : {},
       each.value.capacity_reservation_selector_terms != null ? { capacityReservationSelectorTerms = each.value.capacity_reservation_selector_terms } : {},
       each.value.pod_subnet_selector_terms != null ? { podSubnetSelectorTerms = each.value.pod_subnet_selector_terms } : {},

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -26,8 +26,8 @@ locals {
   }
 
   # Split node pools by mode for the appropriate NodeClass resource
-  self_managed_node_pools = var.eks_auto_mode_enabled ? {} : local.node_pools
-  auto_mode_node_pools    = var.eks_auto_mode_enabled ? local.node_pools : {}
+  self_managed_node_pools = module.eks.outputs.auto_mode_enabled ? {} : local.node_pools
+  auto_mode_node_pools    = module.eks.outputs.auto_mode_enabled ? local.node_pools : {}
 }
 
 # Self-managed Karpenter EC2NodeClass (karpenter.k8s.aws/v1)
@@ -67,8 +67,14 @@ resource "kubernetes_manifest" "ec2_node_class" {
 }
 
 # Auto Mode NodeClass (eks.amazonaws.com/v1)
-# https://docs.aws.amazon.com/eks/latest/userguide/automode.html
-# Auto Mode NodeClass has a minimal spec - EC2-specific fields are not supported.
+# https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html
+# Auto Mode NodeClass does not support EC2-specific fields like
+# amiSelectorTerms, metadataOptions, blockDeviceMappings, amiFamily,
+# detailedMonitoring, or userData.
+#
+# Note: custom tags are NOT supported in Auto Mode NodeClass.
+# The AmazonEKSComputePolicy restricts launch template tag keys to
+# eks:* and kubernetes.io/cluster/* patterns only.
 resource "kubernetes_manifest" "auto_mode_node_class" {
   for_each = local.auto_mode_node_pools
 
@@ -79,8 +85,29 @@ resource "kubernetes_manifest" "auto_mode_node_class" {
       name = coalesce(each.value.name, each.key)
     }
     spec = merge(
-      {},
-      try(length(each.value.labels), 0) > 0 ? { tags = module.this.tags } : { tags = module.this.tags },
+      {
+        # Required fields
+        role = module.eks.outputs.auto_mode_node_role_name
+        subnetSelectorTerms = [for id in(each.value.private_subnets_enabled ? local.private_subnet_ids : local.public_subnet_ids) : {
+          id = id
+        }]
+        securityGroupSelectorTerms = [{
+          tags = {
+            "aws:eks:cluster-name" = local.eks_cluster_id
+          }
+        }]
+      },
+      # Optional fields - only included when set
+      each.value.ephemeral_storage != null ? { ephemeralStorage = each.value.ephemeral_storage } : {},
+      each.value.snat_policy != null ? { snatPolicy = each.value.snat_policy } : {},
+      each.value.network_policy != null ? { networkPolicy = each.value.network_policy } : {},
+      each.value.network_policy_event_logs != null ? { networkPolicyEventLogs = each.value.network_policy_event_logs } : {},
+      each.value.advanced_networking != null ? { advancedNetworking = each.value.advanced_networking } : {},
+      each.value.advanced_security != null ? { advancedSecurity = each.value.advanced_security } : {},
+      each.value.certificate_bundles != null ? { certificateBundles = each.value.certificate_bundles } : {},
+      each.value.capacity_reservation_selector_terms != null ? { capacityReservationSelectorTerms = each.value.capacity_reservation_selector_terms } : {},
+      each.value.pod_subnet_selector_terms != null ? { podSubnetSelectorTerms = each.value.pod_subnet_selector_terms } : {},
+      each.value.pod_security_group_selector_terms != null ? { podSecurityGroupSelectorTerms = each.value.pod_security_group_selector_terms } : {},
     )
   }
 }

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -19,7 +19,7 @@ locals {
   # which will cause perpetual diff in the Terraform plan.
   # We strip out the null values from block_device_mappings here, because it is too complicated to do inline.
   node_block_device_mappings = { for pk, pv in local.node_pools : pk => [
-    for i, map in pv.block_device_mappings : merge({
+    for i, map in coalesce(pv.block_device_mappings, []) : merge({
       for dk, dv in map : dk => dv if dk != "ebs" && dv != null
     }, try(length(map.ebs), 0) == 0 ? {} : { ebs = { for ek, ev in map.ebs : ek => ev if ev != null } })
     ]

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -87,7 +87,20 @@ resource "kubernetes_manifest" "auto_mode_node_class" {
     spec = merge(
       {
         # Required fields
-        role = module.eks.outputs.auto_mode_node_role_name
+resource "kubernetes_manifest" "auto_mode_node_class" {
+  for_each = local.auto_mode_node_pools
+
+  lifecycle {
+    precondition {
+      condition     = module.eks.outputs.auto_mode_node_role_name != null && module.eks.outputs.auto_mode_node_role_name != "deleted"
+      error_message = "EKS Auto Mode requires eks.auto_mode_node_role_name to be set to a valid IAM role name."
+    }
+  }
+
+  manifest = {
+    role = module.eks.outputs.auto_mode_node_role_name
+  }
+}
         subnetSelectorTerms = [for id in(each.value.private_subnets_enabled ? local.private_subnet_ids : local.public_subnet_ids) : {
           id = id
         }]

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -98,7 +98,7 @@ resource "kubernetes_manifest" "auto_mode_node_class" {
         }]
       },
       # Optional fields - only included when set
-      each.value.ephemeral_storage != null ? { ephemeralStorage = each.value.ephemeral_storage } : {},
+      each.value.ephemeral_storage != null ? { ephemeralStorage = { for k, v in each.value.ephemeral_storage : k => v if v != null } } : {},
       each.value.snat_policy != null ? { snatPolicy = each.value.snat_policy } : {},
       each.value.network_policy != null ? { networkPolicy = each.value.network_policy } : {},
       each.value.network_policy_event_logs != null ? { networkPolicyEventLogs = each.value.network_policy_event_logs } : {},

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -1,4 +1,4 @@
-# This provisions the EC2NodeClass for the NodePool.
+# This provisions the NodeClass for the NodePool.
 # https://karpenter.sh/docs/concepts/nodeclasses/
 #
 # We keep it separate from the NodePool creation,
@@ -7,7 +7,11 @@
 # with the Karpenter documentation, and to track changes as
 # Karpenter evolves.
 #
-
+# When eks_auto_mode_enabled is true, we create a simplified NodeClass
+# using the eks.amazonaws.com/v1 API instead of karpenter.k8s.aws/v1.
+# Auto Mode NodeClass does not support EC2-specific fields like
+# role, subnetSelectorTerms, securityGroupSelectorTerms, amiSelectorTerms,
+# metadataOptions, blockDeviceMappings, amiFamily, detailedMonitoring, or userData.
 
 locals {
   # If you include a field but set it to null, the field will be omitted from the Kubernetes resource,
@@ -20,11 +24,16 @@ locals {
     }, try(length(map.ebs), 0) == 0 ? {} : { ebs = { for ek, ev in map.ebs : ek => ev if ev != null } })
     ]
   }
+
+  # Split node pools by mode for the appropriate NodeClass resource
+  self_managed_node_pools = var.eks_auto_mode_enabled ? {} : local.node_pools
+  auto_mode_node_pools    = var.eks_auto_mode_enabled ? local.node_pools : {}
 }
 
+# Self-managed Karpenter EC2NodeClass (karpenter.k8s.aws/v1)
 # https://karpenter.sh/docs/concepts/nodeclasses/
 resource "kubernetes_manifest" "ec2_node_class" {
-  for_each = local.node_pools
+  for_each = local.self_managed_node_pools
 
   manifest = {
     apiVersion = "karpenter.k8s.aws/v1"
@@ -54,5 +63,24 @@ resource "kubernetes_manifest" "ec2_node_class" {
       each.value.ami_family == null ? {} : {
         amiFamily = each.value.ami_family
     })
+  }
+}
+
+# Auto Mode NodeClass (eks.amazonaws.com/v1)
+# https://docs.aws.amazon.com/eks/latest/userguide/automode.html
+# Auto Mode NodeClass has a minimal spec - EC2-specific fields are not supported.
+resource "kubernetes_manifest" "auto_mode_node_class" {
+  for_each = local.auto_mode_node_pools
+
+  manifest = {
+    apiVersion = local.node_class_api_version
+    kind       = local.node_class_kind
+    metadata = {
+      name = coalesce(each.value.name, each.key)
+    }
+    spec = merge(
+      {},
+      try(length(each.value.labels), 0) > 0 ? { tags = module.this.tags } : { tags = module.this.tags },
+    )
   }
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -7,6 +7,11 @@ locals {
   private_subnet_ids = module.vpc.outputs.private_subnet_ids
   public_subnet_ids  = module.vpc.outputs.public_subnet_ids
 
+  # Auto Mode uses a different NodeClass API
+  node_class_api_version = var.eks_auto_mode_enabled ? "eks.amazonaws.com/v1" : "karpenter.k8s.aws/v1"
+  node_class_kind        = var.eks_auto_mode_enabled ? "NodeClass" : "EC2NodeClass"
+  node_class_group       = var.eks_auto_mode_enabled ? "eks.amazonaws.com" : "karpenter.k8s.aws"
+
   node_pools = { for k, v in var.node_pools : k => v if local.enabled }
   kubelets_specs_filtered = { for k, v in local.node_pools : k => {
     for kk, vv in v.kubelet : kk => vv if vv != null
@@ -48,8 +53,8 @@ resource "kubernetes_manifest" "node_pool" {
         )
         spec = merge({
           nodeClassRef = {
-            group = "karpenter.k8s.aws"
-            kind  = "EC2NodeClass"
+            group = local.node_class_group
+            kind  = local.node_class_kind
             name  = coalesce(each.value.name, each.key)
           },
           expireAfter = each.value.disruption.max_instance_lifetime
@@ -77,7 +82,7 @@ resource "kubernetes_manifest" "node_pool" {
     }
   }
 
-  depends_on = [kubernetes_manifest.ec2_node_class]
+  depends_on = [kubernetes_manifest.ec2_node_class, kubernetes_manifest.auto_mode_node_class]
 
   # Marks the field as managed by Kubernetes to avoid continually detecting drift
   # https://github.com/hashicorp/terraform-provider-kubernetes/issues/1378
@@ -85,4 +90,14 @@ resource "kubernetes_manifest" "node_pool" {
     "spec.template.spec.taints",
     "spec.disruption.budgets"
   ]
+}
+
+check "auto_mode_node_pool_name_conflict" {
+  assert {
+    condition = !var.eks_auto_mode_enabled || length(setintersection(
+      toset([for k, v in var.node_pools : coalesce(v.name, k)]),
+      toset(["general-purpose", "system"])
+    )) == 0
+    error_message = "Custom NodePool names cannot conflict with Auto Mode built-in pools: 'general-purpose' and 'system'."
+  }
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -103,3 +103,10 @@ check "auto_mode_node_pool_name_conflict" {
     error_message = "Custom NodePool names cannot conflict with Auto Mode built-in pools: 'general-purpose' and 'system'."
   }
 }
+
+check "auto_mode_node_role_name" {
+  assert {
+    condition     = !local.enabled || !module.eks.outputs.auto_mode_enabled || (module.eks.outputs.auto_mode_node_role_name != null && module.eks.outputs.auto_mode_node_role_name != "deleted")
+    error_message = "EKS Auto Mode requires eks.auto_mode_node_role_name to be set. Ensure the eks/cluster component outputs auto_mode_node_role_name and is at v1.541.0+."
+  }
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -88,6 +88,7 @@ resource "kubernetes_manifest" "node_pool" {
   # Marks the field as managed by Kubernetes to avoid continually detecting drift
   # https://github.com/hashicorp/terraform-provider-kubernetes/issues/1378
   computed_fields = [
+    "metadata.annotations",
     "spec.template.spec.taints",
     "spec.disruption.budgets"
   ]

--- a/src/main.tf
+++ b/src/main.tf
@@ -95,7 +95,7 @@ resource "kubernetes_manifest" "node_pool" {
 
 check "auto_mode_node_pool_name_conflict" {
   assert {
-    condition = !module.eks.outputs.auto_mode_enabled || length(setintersection(
+    condition = !local.enabled || !module.eks.outputs.auto_mode_enabled || length(setintersection(
       toset([for k, v in var.node_pools : coalesce(v.name, k)]),
       toset(["general-purpose", "system"])
     )) == 0

--- a/src/main.tf
+++ b/src/main.tf
@@ -8,9 +8,9 @@ locals {
   public_subnet_ids  = module.vpc.outputs.public_subnet_ids
 
   # Auto Mode uses a different NodeClass API
-  node_class_api_version = var.eks_auto_mode_enabled ? "eks.amazonaws.com/v1" : "karpenter.k8s.aws/v1"
-  node_class_kind        = var.eks_auto_mode_enabled ? "NodeClass" : "EC2NodeClass"
-  node_class_group       = var.eks_auto_mode_enabled ? "eks.amazonaws.com" : "karpenter.k8s.aws"
+  node_class_api_version = module.eks.outputs.auto_mode_enabled ? "eks.amazonaws.com/v1" : "karpenter.k8s.aws/v1"
+  node_class_kind        = module.eks.outputs.auto_mode_enabled ? "NodeClass" : "EC2NodeClass"
+  node_class_group       = module.eks.outputs.auto_mode_enabled ? "eks.amazonaws.com" : "karpenter.k8s.aws"
 
   node_pools = { for k, v in var.node_pools : k => v if local.enabled }
   kubelets_specs_filtered = { for k, v in local.node_pools : k => {
@@ -61,7 +61,8 @@ resource "kubernetes_manifest" "node_pool" {
           },
           try(length(each.value.requirements), 0) == 0 ? {} : {
             requirements = [for r in each.value.requirements : merge({
-              key      = r.key
+              # Auto Mode uses eks.amazonaws.com/* labels instead of karpenter.k8s.aws/*
+              key      = module.eks.outputs.auto_mode_enabled ? replace(r.key, "karpenter.k8s.aws/", "eks.amazonaws.com/") : r.key
               operator = r.operator
               },
               try(length(r.values), 0) == 0 ? {} : {
@@ -94,7 +95,7 @@ resource "kubernetes_manifest" "node_pool" {
 
 check "auto_mode_node_pool_name_conflict" {
   assert {
-    condition = !var.eks_auto_mode_enabled || length(setintersection(
+    condition = !module.eks.outputs.auto_mode_enabled || length(setintersection(
       toset([for k, v in var.node_pools : coalesce(v.name, k)]),
       toset(["general-purpose", "system"])
     )) == 0

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -17,6 +17,8 @@ module "eks" {
     eks_cluster_identity_oidc_issuer       = coalesce(var.eks.eks_cluster_identity_oidc_issuer, "deleted")
     karpenter_iam_role_name                = var.eks.karpenter_iam_role_name
     karpenter_node_role_arn                = coalesce(var.eks.karpenter_node_role_arn, "deleted")
+    auto_mode_node_role_name               = coalesce(var.eks.auto_mode_node_role_name, "deleted")
+    auto_mode_enabled                      = coalesce(var.eks.auto_mode_enabled, false)
   }
 
   context = module.this.context

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -4,7 +4,7 @@ locals {
 
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   bypass    = !local.account_map_enabled
   component = var.eks_component_name
@@ -26,7 +26,7 @@ module "eks" {
 
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   bypass    = !local.account_map_enabled
   component = var.vpc_component_name

--- a/src/variables-account-map.tf
+++ b/src/variables-account-map.tf
@@ -1,0 +1,10 @@
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-EOT
+    Enable account map and remote state lookups.
+    When `true`, fetch EKS cluster and VPC information from Terraform remote state.
+    When `false`, use the `eks` and `vpc` variables to provide values directly.
+    EOT
+  default     = true
+  nullable    = false
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -219,10 +219,10 @@ variable "node_pools" {
 
     # Ephemeral storage configuration for Auto Mode nodes
     ephemeral_storage = optional(object({
-      size       = optional(string)   # Range: 1-59000Gi
-      iops       = optional(number)   # Range: 3000-16000
-      throughput = optional(number)   # Range: 125-1000
-      kmsKeyID   = optional(string)   # KMS key ID, ARN, alias name, or alias ARN
+      size       = optional(string) # Range: 1-59000Gi
+      iops       = optional(number) # Range: 3000-16000
+      throughput = optional(number) # Range: 125-1000
+      kmsKeyID   = optional(string) # KMS key ID, ARN, alias name, or alias ARN
     }))
     # SNAT policy: "Random" or "Disabled"
     snat_policy = optional(string)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -3,17 +3,6 @@ variable "region" {
   description = "AWS Region"
 }
 
-variable "account_map_enabled" {
-  type        = bool
-  description = <<-EOT
-    Enable account map and remote state lookups.
-    When `true`, fetch EKS cluster and VPC information from Terraform remote state.
-    When `false`, use the `eks` and `vpc` variables to provide values directly.
-    EOT
-  default     = true
-  nullable    = false
-}
-
 variable "eks_component_name" {
   type        = string
   description = <<-EOT

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -42,6 +42,8 @@ variable "eks" {
     eks_cluster_identity_oidc_issuer       = optional(string, "")
     karpenter_iam_role_name                = optional(string, "")
     karpenter_node_role_arn                = optional(string, "")
+    auto_mode_node_role_name               = optional(string, "")
+    auto_mode_enabled                      = optional(bool, false)
   })
   description = <<-EOT
     EKS cluster configuration to use when `account_map_enabled` is `false`.
@@ -55,6 +57,8 @@ variable "eks" {
     eks_cluster_identity_oidc_issuer       = ""
     karpenter_iam_role_name                = ""
     karpenter_node_role_arn                = ""
+    auto_mode_node_role_name               = ""
+    auto_mode_enabled                      = false
   }
 }
 
@@ -71,13 +75,6 @@ variable "vpc" {
     private_subnet_ids = []
     public_subnet_ids  = []
   }
-}
-
-variable "eks_auto_mode_enabled" {
-  type        = bool
-  description = "Set to true if the EKS cluster has Auto Mode compute enabled. Changes the NodeClass API from EC2NodeClass (karpenter.k8s.aws/v1) to NodeClass (eks.amazonaws.com/v1) for Auto Mode compatibility."
-  default     = false
-  nullable    = false
 }
 
 variable "node_pools" {
@@ -179,14 +176,14 @@ variable "node_pools" {
     # Selectors for the AMI used by Karpenter provisioner when provisioning nodes.
     # Usually use { alias = "<family>@latest" } but version can be pinned instead of "latest".
     # Based on the ami_selector_terms, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)
-    ami_selector_terms = list(any)
+    ami_selector_terms = optional(list(any))
     # Karpenter nodes block device mappings. Controls the Elastic Block Storage volumes that Karpenter attaches to provisioned nodes.
     # Karpenter uses default block device mappings for the AMI Family specified.
     # For example, the Bottlerocket AMI Family defaults with two block device mappings,
     # and normally you only want to scale `/dev/xvdb` where Containers and there storage are stored.
     # Most other AMIs only have one device mapping at `/dev/xvda`.
     # See https://karpenter.sh/docs/concepts/nodeclasses/#specblockdevicemappings for more details
-    block_device_mappings = list(object({
+    block_device_mappings = optional(list(object({
       deviceName = string
       ebs = optional(object({
         volumeSize          = string
@@ -198,7 +195,7 @@ variable "node_pools" {
         snapshotID          = optional(string)
         throughput          = optional(number)
       }))
-    }))
+    })))
     # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture, and capacity type (such as AWS spot or on-demand). See https://karpenter.sh/v0.18.0/provisioner/#specrequirements for more details
     requirements = list(object({
       key      = string
@@ -212,6 +209,50 @@ variable "node_pools" {
     #   https://karpenter.sh/docs/concepts/nodepools/#spectemplatespeckubelet
     #   https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
     kubelet = optional(any, {})
+
+    ###########################################################################
+    # Auto Mode NodeClass fields (eks.amazonaws.com/v1)
+    # https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html
+    # These fields are only used when eks_auto_mode_enabled = true.
+    # They are ignored for self-managed Karpenter (karpenter.k8s.aws/v1).
+    ###########################################################################
+
+    # Ephemeral storage configuration for Auto Mode nodes
+    ephemeral_storage = optional(object({
+      size       = optional(string)   # Range: 1-59000Gi
+      iops       = optional(number)   # Range: 3000-16000
+      throughput = optional(number)   # Range: 125-1000
+      kmsKeyID   = optional(string)   # KMS key ID, ARN, alias name, or alias ARN
+    }))
+    # SNAT policy: "Random" or "Disabled"
+    snat_policy = optional(string)
+    # Network policy: "DefaultAllow" or "DefaultDeny"
+    network_policy = optional(string)
+    # Network policy event logs: "Disabled" or "Enabled"
+    network_policy_event_logs = optional(string)
+    # Advanced networking configuration
+    advanced_networking = optional(object({
+      associatePublicIPAddress = optional(bool)
+      httpsProxy               = optional(string)
+      noProxy                  = optional(list(string))
+      ipv4PrefixSize           = optional(string) # "Auto" or "32"
+      enableV4Egress           = optional(bool)
+    }))
+    # Advanced security configuration
+    advanced_security = optional(object({
+      fips = optional(bool) # US regions only
+    }))
+    # Custom certificate bundles (e.g. for proxy)
+    certificate_bundles = optional(list(object({
+      name = string
+      data = string
+    })))
+    # Capacity reservation selector terms
+    capacity_reservation_selector_terms = optional(list(any))
+    # Pod subnet selector terms (must be set together with pod_security_group_selector_terms)
+    pod_subnet_selector_terms = optional(list(any))
+    # Pod security group selector terms (must be set together with pod_subnet_selector_terms)
+    pod_security_group_selector_terms = optional(list(any))
   }))
   description = "Configuration for node pools. See code for details."
   nullable    = false

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -176,7 +176,7 @@ variable "node_pools" {
     # Selectors for the AMI used by Karpenter provisioner when provisioning nodes.
     # Usually use { alias = "<family>@latest" } but version can be pinned instead of "latest".
     # Based on the ami_selector_terms, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)
-    ami_selector_terms = optional(list(any))
+    ami_selector_terms = optional(list(any), [])
     # Karpenter nodes block device mappings. Controls the Elastic Block Storage volumes that Karpenter attaches to provisioned nodes.
     # Karpenter uses default block device mappings for the AMI Family specified.
     # For example, the Bottlerocket AMI Family defaults with two block device mappings,
@@ -213,7 +213,7 @@ variable "node_pools" {
     ###########################################################################
     # Auto Mode NodeClass fields (eks.amazonaws.com/v1)
     # https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html
-    # These fields are only used when eks_auto_mode_enabled = true.
+    # These fields are only used when auto_mode_enabled = true.
     # They are ignored for self-managed Karpenter (karpenter.k8s.aws/v1).
     ###########################################################################
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -84,6 +84,13 @@ variable "vpc" {
   }
 }
 
+variable "eks_auto_mode_enabled" {
+  type        = bool
+  description = "Set to true if the EKS cluster has Auto Mode compute enabled. Changes the NodeClass API from EC2NodeClass (karpenter.k8s.aws/v1) to NodeClass (eks.amazonaws.com/v1) for Auto Mode compatibility."
+  default     = false
+  nullable    = false
+}
+
 variable "node_pools" {
   type = map(object({
     # The name of the Karpenter provisioner. The map key is used if this is not set.

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.7.1, != 2.21.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -103,6 +103,99 @@ func (s *ComponentSuite) TestBasic() {
 	s.DriftTest(component, stack, &inputs)
 }
 
+func (s *ComponentSuite) TestAutoMode() {
+	const component = "eks/karpenter-node-pool/auto-mode"
+	const stack = "default-test"
+	const awsRegion = "us-east-2"
+
+	inputs := map[string]interface{}{}
+
+	defer s.DestroyAtmosComponent(s.T(), component, stack, &inputs)
+	options, _ := s.DeployAtmosComponent(s.T(), component, stack, &inputs)
+	assert.NotNil(s.T(), options)
+
+	var nodePools map[string]interface{}
+	atmos.OutputStruct(s.T(), options, "node_pools", &nodePools)
+	assert.NotEmpty(s.T(), nodePools)
+
+	clusterOptions := s.GetAtmosOptions("eks/cluster/auto-mode", stack, nil)
+	clusterId := atmos.Output(s.T(), clusterOptions, "eks_cluster_id")
+
+	cluster := awsHelper.GetEksCluster(s.T(), context.Background(), awsRegion, clusterId)
+
+	config, err := awsHelper.NewK8SClientConfig(cluster)
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), config)
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		panic(fmt.Errorf("failed to create dynamic client: %v", err))
+	}
+
+	// Auto Mode uses the eks.amazonaws.com NodeClass CRD instead of
+	// karpenter.k8s.aws/EC2NodeClass.
+	nodeClassGVR := schema.GroupVersionResource{
+		Group:    "eks.amazonaws.com",
+		Version:  "v1",
+		Resource: "nodeclasses",
+	}
+
+	nodeClassList, err := dynamicClient.Resource(nodeClassGVR).Namespace(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	assert.NoError(s.T(), err)
+
+	// We expect at least the one custom NodeClass we created. Auto Mode also
+	// ships built-in NodeClasses, so we look up ours by name rather than count.
+	var customNodeClass *unstructured.Unstructured
+	for i, item := range nodeClassList.Items {
+		if item.GetName() == "custom" {
+			customNodeClass = &nodeClassList.Items[i]
+			break
+		}
+	}
+	assert.NotNil(s.T(), customNodeClass, "expected to find a NodeClass named 'custom'")
+
+	if customNodeClass != nil {
+		conditions, exists, err := unstructured.NestedSlice(customNodeClass.Object, "status", "conditions")
+		assert.NoError(s.T(), err)
+		assert.True(s.T(), exists)
+		for _, condition := range conditions {
+			conditionMap := condition.(map[string]interface{})
+			assert.Equal(s.T(), conditionMap["status"], "True")
+		}
+	}
+
+	nodePoolGVR := schema.GroupVersionResource{
+		Group:    "karpenter.sh",
+		Version:  "v1",
+		Resource: "nodepools",
+	}
+
+	nodePoolsList, err := dynamicClient.Resource(nodePoolGVR).Namespace(corev1.NamespaceAll).List(context.Background(), metav1.ListOptions{})
+	assert.NoError(s.T(), err)
+
+	// Auto Mode includes built-in pools (general-purpose, system) plus our custom one.
+	var customNodePool *unstructured.Unstructured
+	for i, item := range nodePoolsList.Items {
+		if item.GetName() == "custom" {
+			customNodePool = &nodePoolsList.Items[i]
+			break
+		}
+	}
+	assert.NotNil(s.T(), customNodePool, "expected to find a NodePool named 'custom'")
+
+	if customNodePool != nil {
+		conditions, exists, err := unstructured.NestedSlice(customNodePool.Object, "status", "conditions")
+		assert.NoError(s.T(), err)
+		assert.True(s.T(), exists)
+		for _, condition := range conditions {
+			conditionMap := condition.(map[string]interface{})
+			assert.Equal(s.T(), conditionMap["status"], "True")
+		}
+	}
+
+	s.DriftTest(component, stack, &inputs)
+}
+
 func (s *ComponentSuite) TestEnabledFlag() {
 	const component = "eks/karpenter-node-pool/disabled"
 	const stack = "default-test"
@@ -119,6 +212,7 @@ func TestRunSuite(t *testing.T) {
 	suite := new(ComponentSuite)
 	suite.AddDependency(t, "vpc", "default-test", nil)
 	suite.AddDependency(t, "eks/cluster", "default-test", nil)
+	suite.AddDependency(t, "eks/cluster/auto-mode", "default-test", nil)
 	suite.AddDependency(t, "eks/karpenter-controller", "default-test", nil)
 	helper.Run(t, suite)
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -93,8 +93,9 @@ func (s *ComponentSuite) TestBasic() {
 	assert.NotNil(s.T(), config)
 
 	dynamicClient, err := dynamic.NewForConfig(config)
+	assert.NoError(s.T(), err)
 	if err != nil {
-		panic(fmt.Errorf("failed to create dynamic client: %v", err))
+		return
 	}
 
 	// Define the GroupVersionResource for the EC2NodeClass CRD
@@ -170,8 +171,9 @@ func (s *ComponentSuite) TestAutoMode() {
 	assert.NotNil(s.T(), config)
 
 	dynamicClient, err := dynamic.NewForConfig(config)
+	assert.NoError(s.T(), err)
 	if err != nil {
-		panic(fmt.Errorf("failed to create dynamic client: %v", err))
+		return
 	}
 
 	// Auto Mode uses the eks.amazonaws.com NodeClass CRD instead of

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -22,6 +22,24 @@ type ComponentSuite struct {
 	helper.TestSuite
 }
 
+// assertReadyCondition verifies the resource has a Ready condition with status "True".
+// Auto Mode resources expose additional conditions (e.g. disruption-related) that are
+// not always "True", so iterating over every condition would produce false negatives.
+func assertReadyCondition(t *testing.T, conditions []interface{}, resourceName string) {
+	t.Helper()
+	for _, condition := range conditions {
+		conditionMap, ok := condition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if conditionMap["type"] == "Ready" {
+			assert.Equal(t, "True", conditionMap["status"], "%s Ready condition should be True", resourceName)
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("%s has no Ready condition", resourceName))
+}
+
 func (s *ComponentSuite) TestBasic() {
 	const component = "eks/karpenter-node-pool/basic"
 	const stack = "default-test"
@@ -158,10 +176,7 @@ func (s *ComponentSuite) TestAutoMode() {
 		conditions, exists, err := unstructured.NestedSlice(customNodeClass.Object, "status", "conditions")
 		assert.NoError(s.T(), err)
 		assert.True(s.T(), exists)
-		for _, condition := range conditions {
-			conditionMap := condition.(map[string]interface{})
-			assert.Equal(s.T(), conditionMap["status"], "True")
-		}
+		assertReadyCondition(s.T(), conditions, "NodeClass custom")
 	}
 
 	nodePoolGVR := schema.GroupVersionResource{
@@ -187,10 +202,7 @@ func (s *ComponentSuite) TestAutoMode() {
 		conditions, exists, err := unstructured.NestedSlice(customNodePool.Object, "status", "conditions")
 		assert.NoError(s.T(), err)
 		assert.True(s.T(), exists)
-		for _, condition := range conditions {
-			conditionMap := condition.(map[string]interface{})
-			assert.Equal(s.T(), conditionMap["status"], "True")
-		}
+		assertReadyCondition(s.T(), conditions, "NodePool custom")
 	}
 
 	s.DriftTest(component, stack, &inputs)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cloudposse/test-helpers/pkg/atmos"
 	helper "github.com/cloudposse/test-helpers/pkg/atmos/component-helper"
 	awsHelper "github.com/cloudposse/test-helpers/pkg/aws"
+	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,22 +24,39 @@ type ComponentSuite struct {
 	helper.TestSuite
 }
 
-// assertReadyCondition verifies the resource has a Ready condition with status "True".
-// Auto Mode resources expose additional conditions (e.g. disruption-related) that are
-// not always "True", so iterating over every condition would produce false negatives.
-func assertReadyCondition(t *testing.T, conditions []interface{}, resourceName string) {
+// waitForReadyCondition polls the given resource until its Ready condition is "True"
+// or the timeout expires. Auto Mode resources may take time to reconcile after creation.
+func waitForReadyCondition(t *testing.T, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, name string, timeout time.Duration) {
 	t.Helper()
-	for _, condition := range conditions {
-		conditionMap, ok := condition.(map[string]interface{})
-		if !ok {
-			continue
+	retry.DoWithRetry(t, fmt.Sprintf("Waiting for %s Ready condition", name), int(timeout.Seconds()/10), 10*time.Second, func() (string, error) {
+		resource, err := dynamicClient.Resource(gvr).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("failed to get resource %s: %v", name, err)
 		}
-		if conditionMap["type"] == "Ready" {
-			assert.Equal(t, "True", conditionMap["status"], "%s Ready condition should be True", resourceName)
-			return
+
+		conditions, exists, err := unstructured.NestedSlice(resource.Object, "status", "conditions")
+		if err != nil {
+			return "", fmt.Errorf("failed to get conditions for %s: %v", name, err)
 		}
-	}
-	assert.Fail(t, fmt.Sprintf("%s has no Ready condition", resourceName))
+		if !exists {
+			return "", fmt.Errorf("%s has no status conditions yet", name)
+		}
+
+		for _, condition := range conditions {
+			conditionMap, ok := condition.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if conditionMap["type"] == "Ready" {
+				status, _ := conditionMap["status"].(string)
+				if status == "True" {
+					return "Ready", nil
+				}
+				return "", fmt.Errorf("%s Ready condition is %q, waiting for True", name, status)
+			}
+		}
+		return "", fmt.Errorf("%s has no Ready condition", name)
+	})
 }
 
 func (s *ComponentSuite) TestBasic() {
@@ -173,10 +192,8 @@ func (s *ComponentSuite) TestAutoMode() {
 	assert.NotNil(s.T(), customNodeClass, "expected to find a NodeClass named 'custom'")
 
 	if customNodeClass != nil {
-		conditions, exists, err := unstructured.NestedSlice(customNodeClass.Object, "status", "conditions")
-		assert.NoError(s.T(), err)
-		assert.True(s.T(), exists)
-		assertReadyCondition(s.T(), conditions, "NodeClass custom")
+		// Auto Mode resources may take time to reconcile after creation.
+		waitForReadyCondition(s.T(), dynamicClient, nodeClassGVR, "custom", 5*time.Minute)
 	}
 
 	nodePoolGVR := schema.GroupVersionResource{
@@ -199,10 +216,8 @@ func (s *ComponentSuite) TestAutoMode() {
 	assert.NotNil(s.T(), customNodePool, "expected to find a NodePool named 'custom'")
 
 	if customNodePool != nil {
-		conditions, exists, err := unstructured.NestedSlice(customNodePool.Object, "status", "conditions")
-		assert.NoError(s.T(), err)
-		assert.True(s.T(), exists)
-		assertReadyCondition(s.T(), conditions, "NodePool custom")
+		// Auto Mode resources may take time to reconcile after creation.
+		waitForReadyCondition(s.T(), dynamicClient, nodePoolGVR, "custom", 5*time.Minute)
 	}
 
 	s.DriftTest(component, stack, &inputs)

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -28,7 +28,12 @@ type ComponentSuite struct {
 // or the timeout expires. Auto Mode resources may take time to reconcile after creation.
 func waitForReadyCondition(t *testing.T, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, name string, timeout time.Duration) {
 	t.Helper()
-	retry.DoWithRetry(t, fmt.Sprintf("Waiting for %s Ready condition", name), int(timeout.Seconds()/10), 10*time.Second, func() (string, error) {
+	maxRetries := int(timeout.Seconds() / 10)
+	if maxRetries < 1 {
+		maxRetries = 1
+	}
+
+	retry.DoWithRetry(t, fmt.Sprintf("Waiting for %s Ready condition", name), maxRetries, 10*time.Second, func() (string, error) {
 		resource, err := dynamicClient.Resource(gvr).Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {
 			return "", fmt.Errorf("failed to get resource %s: %v", name, err)

--- a/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
+++ b/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
@@ -1,0 +1,49 @@
+components:
+  terraform:
+    eks/cluster/auto-mode:
+      metadata:
+        component: eks/cluster
+      vars:
+        enabled: true
+        attributes:
+          - "auto"
+
+        # Auto Mode manages compute (Karpenter), networking, and storage.
+        auto_mode_enabled: true
+        # Self-managed Karpenter must be disabled when Auto Mode is enabled.
+        karpenter_iam_role_enabled: false
+
+        # Auto Mode does not need a bootstrap managed node group.
+        managed_node_groups_enabled: false
+        node_groups: {}
+
+        access_config:
+          authentication_mode: "API"
+          bootstrap_cluster_creator_admin_permissions: true
+
+        # Auto Mode does not need Fargate.
+        fargate_profiles: {}
+        legacy_fargate_1_role_per_profile_enabled: false
+
+        addons_depends_on: true
+        deploy_addons_to_fargate: false
+
+        allow_ingress_from_vpc_accounts: []
+        public_access_cidrs: ["0.0.0.0/0"]
+        allowed_cidr_blocks: []
+        allowed_security_groups: []
+
+        enabled_cluster_log_types: []
+        apply_config_map_aws_auth: true
+        availability_zone_abbreviation_type: fixed
+        cluster_private_subnets_only: true
+        cluster_encryption_config_enabled: true
+        cluster_endpoint_private_access: true
+        cluster_endpoint_public_access: true
+        cluster_log_retention_period: 90
+        oidc_provider_enabled: true
+        cluster_kubernetes_version: "1.31"
+
+        # vpc-cni, kube-proxy, coredns, and aws-ebs-csi-driver are managed by Auto Mode
+        # and must not appear in the addons map.
+        addons: {}

--- a/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
+++ b/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
@@ -5,8 +5,7 @@ components:
         component: eks/cluster
       vars:
         enabled: true
-        attributes:
-          - "auto"
+        name: "auto"
 
         # Auto Mode manages compute (Karpenter), networking, and storage.
         auto_mode_enabled: true

--- a/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
+++ b/test/fixtures/stacks/catalog/eks-cluster-auto-mode.yaml
@@ -41,7 +41,7 @@ components:
         cluster_endpoint_public_access: true
         cluster_log_retention_period: 90
         oidc_provider_enabled: true
-        cluster_kubernetes_version: "1.31"
+        cluster_kubernetes_version: "1.33"
 
         # vpc-cni, kube-proxy, coredns, and aws-ebs-csi-driver are managed by Auto Mode
         # and must not appear in the addons map.

--- a/test/fixtures/stacks/catalog/usecase/auto-mode.yaml
+++ b/test/fixtures/stacks/catalog/usecase/auto-mode.yaml
@@ -1,0 +1,73 @@
+components:
+  terraform:
+    eks/karpenter-node-pool/auto-mode:
+      metadata:
+        component: eks/karpenter-node-pool
+      vars:
+        enabled: true
+        # Point at the auto-mode cluster instance.
+        eks_component_name: "eks/cluster/auto-mode"
+        kube_exec_auth_role_arn_enabled: false
+        kube_exec_auth_role_arn: "empty" # fulfills coalesce, but is disabled by above.
+        name: "karpenter-node-pool"
+        node_pools:
+          # Custom NodePool name. Must not collide with the Auto Mode built-in
+          # pools "general-purpose" or "system" (enforced by a check in main.tf).
+          custom:
+            labels:
+              test: test
+            annotations:
+              test: test
+            private_subnets_enabled: true
+            disruption:
+              consolidation_policy: "WhenEmptyOrUnderutilized"
+              consolidate_after: "70s"
+              max_instance_lifetime: "1h"
+              budgets:
+                - nodes: "20%"
+                  reasons:
+                    - "Underutilized"
+                    - "Empty"
+            total_cpu_limit: "100"
+            total_memory_limit: "1000Gi"
+
+            # Auto Mode NodeClass fields (eks.amazonaws.com/v1).
+            # These are ignored when Auto Mode is disabled.
+            ephemeral_storage:
+              size: "80Gi"
+              iops: 3000
+              throughput: 125
+            snat_policy: "Random"
+            network_policy: "DefaultAllow"
+            network_policy_event_logs: "Disabled"
+
+            # Requirements use karpenter.k8s.aws/* keys, which the component
+            # rewrites to eks.amazonaws.com/* automatically when Auto Mode is on.
+            requirements:
+              - key: "karpenter.k8s.aws/instance-cpu"
+                operator: Gt
+                values: ["1"]
+              - key: "karpenter.k8s.aws/instance-cpu"
+                operator: Lt
+                values: ["32"]
+              - key: "karpenter.sh/capacity-type"
+                operator: "In"
+                values:
+                  - "on-demand"
+                  - "spot"
+              - key: "kubernetes.io/arch"
+                operator: "In"
+                values:
+                  - "amd64"
+              - key: "karpenter.k8s.aws/instance-family"
+                operator: "In"
+                values:
+                  - c5
+                  - c6i
+                  - c7i
+                  - m5
+                  - m6i
+                  - m7i
+                  - r5
+                  - r6i
+                  - r7i

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -2,6 +2,8 @@ import:
   - orgs/default/test/_defaults
   - catalog/vpc
   - catalog/eks-cluster
+  - catalog/eks-cluster-auto-mode
   - catalog/eks-karpenter-controller
   - catalog/usecase/basic
+  - catalog/usecase/auto-mode
   - catalog/usecase/disabled

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -31,7 +31,7 @@ spec:
 
     - component: "eks/cluster"
       source: github.com/cloudposse-terraform-components/aws-eks-cluster.git//src?ref={{.Version}}
-      version: v1.540.3
+      version: v1.541.1
 
       targets:
         - "components/terraform/eks/cluster"

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   sources:
     - component: "account-map"
-      source: github.com/cloudposse/terraform-aws-components.git//modules/account-map?ref={{.Version}}
-      version: 1.520.0
+      source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -19,7 +19,7 @@ spec:
 
     - component: "eks/karpenter-controller"
       source: github.com/cloudposse-terraform-components/aws-eks-karpenter-controller.git//src?ref={{.Version}}
-      version: v1.536.2
+      version: v1.538.2
       targets:
         - "components/terraform/eks/karpenter-controller"
       included_paths:
@@ -31,7 +31,8 @@ spec:
 
     - component: "eks/cluster"
       source: github.com/cloudposse-terraform-components/aws-eks-cluster.git//src?ref={{.Version}}
-      version: v1.538.0
+      version: v1.540.3
+
       targets:
         - "components/terraform/eks/cluster"
       included_paths:
@@ -43,7 +44,7 @@ spec:
 
     - component: "vpc"
       source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
-      version: v1.538.1
+      version: v2.1.2
       targets:
         - "components/terraform/vpc"
       included_paths:

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/cloudposse/test-helpers v0.23.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/gruntwork-io/terratest v0.48.2 // indirect
+	github.com/gruntwork-io/terratest v0.48.2
 	github.com/mattn/go-zglob v0.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
## Summary

Adapts the Karpenter node-pool component to work with EKS Auto Mode by detecting `auto_mode_enabled` from the upstream `eks` component and emitting the correct NodeClass API.

- Conditionally provisions an Auto Mode `NodeClass` (`eks.amazonaws.com/v1`) instead of `EC2NodeClass` (`karpenter.k8s.aws/v1`) based on `module.eks.outputs.auto_mode_enabled`
- `NodePool.nodeClassRef` group/kind and `requirements` label keys are rewritten from `karpenter.k8s.aws/*` to `eks.amazonaws.com/*` in Auto Mode
- Auto Mode NodeClass omits unsupported EC2-specific fields (`amiSelectorTerms`, `metadataOptions`, `blockDeviceMappings`, `amiFamily`, `detailedMonitoring`, `userData`, custom tags) and uses `auto_mode_node_role_name` from the EKS remote state
- New optional `node_pools` fields for Auto Mode NodeClass: `ephemeral_storage`, `snat_policy`, `network_policy`, `network_policy_event_logs`, `advanced_networking`, `advanced_security`, `certificate_bundles`, `capacity_reservation_selector_terms`, `pod_subnet_selector_terms`, `pod_security_group_selector_terms`
- `ami_selector_terms` and `block_device_mappings` are now optional (not required in Auto Mode)
- `check` block prevents custom NodePool names from colliding with the built-in `general-purpose` and `system` pools
- `eks` variable extended with `auto_mode_node_role_name` and `auto_mode_enabled`
- Adds `src/UPDATING.md` documenting the migration: required upstream `eks/cluster` version (`v1.541.0`+), remote-state `2.0.0` bump, new `cloudposse/utils` provider, reserved pool names, requirement-key rewriting, ignored EC2-only fields, new Auto Mode fields, and the resource-replacement caveat when switching modes

## Test plan

- [ ] `terraform plan` against a non-Auto-Mode cluster shows no diff (backward compatible)
- [ ] `terraform plan` against an Auto Mode cluster emits `NodeClass` (`eks.amazonaws.com/v1`) and rewritten NodePool requirement keys
- [ ] Validation rejects `node_pools` entries named `general-purpose` or `system` when Auto Mode is enabled
- [ ] Optional Auto Mode fields render only when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS EKS Auto Mode support for Karpenter node pools with conditional provisioning between self-managed and Auto Mode
  * New optional Auto Mode node pool settings (ephemeral storage, SNAT, network policies, advanced networking/security, certificate bundles, capacity/pod selectors)
  * Runtime validation to forbid reserved Auto Mode node pool names and rewrite requirement keys for Auto Mode

* **Documentation**
  * Added migration and upgrade guide for switching to Auto Mode

* **Tests**
  * Added tests and fixtures validating Auto Mode cluster and node pool behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
