### PR TITLE
feat: support instanceStorePolicy on the EC2NodeClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,16 +222,6 @@ components:
                   volumeType: gp3
                   encrypted: true
                   deleteOnTermination: true
-            # Optionally place the kubelet and containerd (and therefore pod
-            # ephemeral-storage: image layers, emptyDir, scratch) on the
-            # instance's local NVMe via RAID0, instead of the EBS root volume.
-            # Useful for ephemeral, IO-heavy workloads (e.g. CI runners) that
-            # otherwise saturate the gp3 root volume's throughput. Requires
-            # instance types that have local NVMe (the *d / *gd families; select
-            # them with a `karpenter.k8s.aws/instance-local-nvme` requirement).
-            # Omit to ignore instance-store volumes. Only valid value: "RAID0".
-            # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
-            # instance_store_policy: "RAID0"
             # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on
             # Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture,
             # and capacity type (such as AWS spot or on-demand).
@@ -275,6 +265,36 @@ components:
                 values:
                   - "amd64"
 ```
+
+## Using local NVMe instance storage
+
+IO-heavy, ephemeral workloads — self-hosted CI runners are the classic case —
+can saturate the throughput of the EBS root volume. To move the kubelet and
+containerd (and therefore pod ephemeral-storage: image layers, `emptyDir`,
+build scratch) onto the instance's local NVMe instead, set
+`instance_store_policy: "RAID0"` on the node pool and require NVMe-capable
+instance types:
+
+```yaml
+node_pools:
+  ci-runners:
+    # ... disruption, limits, ami_selector_terms, block_device_mappings ...
+    instance_store_policy: "RAID0"
+    requirements:
+      # only instance types that actually have local NVMe
+      - key: "karpenter.k8s.aws/instance-local-nvme"
+        operator: Gt
+        values: ["0"]
+      # general-purpose / compute / memory (exclude storage-i, GPU, etc.)
+      - key: "karpenter.k8s.aws/instance-category"
+        operator: In
+        values: ["c", "m", "r"]
+```
+
+The local NVMe is **ephemeral** (wiped on stop/termination), so this suits
+scratch/cache workloads, not anything needing persistence. On AL2 / AL2023 /
+Bottlerocket the RAID0 array is configured automatically, and the node's
+allocatable `ephemeral-storage` becomes the total instance-store size.
 
 > [!IMPORTANT]
 > In Cloud Posse's examples, we avoid pinning modules to specific versions to prevent discrepancies between the documentation

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ components:
                   volumeType: gp3
                   encrypted: true
                   deleteOnTermination: true
+            # Optionally place the kubelet and containerd (and therefore pod
+            # ephemeral-storage: image layers, emptyDir, scratch) on the
+            # instance's local NVMe via RAID0, instead of the EBS root volume.
+            # Useful for ephemeral, IO-heavy workloads (e.g. CI runners) that
+            # otherwise saturate the gp3 root volume's throughput. Requires
+            # instance types that have local NVMe (the *d / *gd families; select
+            # them with a `karpenter.k8s.aws/instance-local-nvme` requirement).
+            # Omit to ignore instance-store volumes. Only valid value: "RAID0".
+            # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
+            # instance_store_policy: "RAID0"
             # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on
             # Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture,
             # and capacity type (such as AWS spot or on-demand).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Not supported:
     cluster.
   - `amiSelectorTerms`. Such terms override the `amiFamily` setting, which is the only AMI selection supported by this
     component.
-  - `instanceStorePolicy`
   - `associatePublicIPAddress`
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -177,16 +177,6 @@ usage: |-
                     volumeType: gp3
                     encrypted: true
                     deleteOnTermination: true
-              # Optionally place the kubelet and containerd (and therefore pod
-              # ephemeral-storage: image layers, emptyDir, scratch) on the
-              # instance's local NVMe via RAID0, instead of the EBS root volume.
-              # Useful for ephemeral, IO-heavy workloads (e.g. CI runners) that
-              # otherwise saturate the gp3 root volume's throughput. Requires
-              # instance types that have local NVMe (the *d / *gd families; select
-              # them with a `karpenter.k8s.aws/instance-local-nvme` requirement).
-              # Omit to ignore instance-store volumes. Only valid value: "RAID0".
-              # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
-              # instance_store_policy: "RAID0"
               # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on
               # Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture,
               # and capacity type (such as AWS spot or on-demand).
@@ -230,6 +220,36 @@ usage: |-
                   values:
                     - "amd64"
   ```
+
+  ## Using local NVMe instance storage
+
+  IO-heavy, ephemeral workloads — self-hosted CI runners are the classic case —
+  can saturate the throughput of the EBS root volume. To move the kubelet and
+  containerd (and therefore pod ephemeral-storage: image layers, `emptyDir`,
+  build scratch) onto the instance's local NVMe instead, set
+  `instance_store_policy: "RAID0"` on the node pool and require NVMe-capable
+  instance types:
+
+  ```yaml
+  node_pools:
+    ci-runners:
+      # ... disruption, limits, ami_selector_terms, block_device_mappings ...
+      instance_store_policy: "RAID0"
+      requirements:
+        # only instance types that actually have local NVMe
+        - key: "karpenter.k8s.aws/instance-local-nvme"
+          operator: Gt
+          values: ["0"]
+        # general-purpose / compute / memory (exclude storage-i, GPU, etc.)
+        - key: "karpenter.k8s.aws/instance-category"
+          operator: In
+          values: ["c", "m", "r"]
+  ```
+
+  The local NVMe is **ephemeral** (wiped on stop/termination), so this suits
+  scratch/cache workloads, not anything needing persistence. On AL2 / AL2023 /
+  Bottlerocket the RAID0 array is configured automatically, and the node's
+  allocatable `ephemeral-storage` becomes the total instance-store size.
 references:
   - name: "https://karpenter.sh"
     description: ""

--- a/README.yaml
+++ b/README.yaml
@@ -19,7 +19,6 @@ description: |-
       cluster.
     - `amiSelectorTerms`. Such terms override the `amiFamily` setting, which is the only AMI selection supported by this
       component.
-    - `instanceStorePolicy`
     - `associatePublicIPAddress`
 usage: |-
   **Stack Level**: Regional

--- a/README.yaml
+++ b/README.yaml
@@ -177,6 +177,16 @@ usage: |-
                     volumeType: gp3
                     encrypted: true
                     deleteOnTermination: true
+              # Optionally place the kubelet and containerd (and therefore pod
+              # ephemeral-storage: image layers, emptyDir, scratch) on the
+              # instance's local NVMe via RAID0, instead of the EBS root volume.
+              # Useful for ephemeral, IO-heavy workloads (e.g. CI runners) that
+              # otherwise saturate the gp3 root volume's throughput. Requires
+              # instance types that have local NVMe (the *d / *gd families; select
+              # them with a `karpenter.k8s.aws/instance-local-nvme` requirement).
+              # Omit to ignore instance-store volumes. Only valid value: "RAID0".
+              # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
+              # instance_store_policy: "RAID0"
               # Set acceptable (In) and unacceptable (Out) Kubernetes and Karpenter values for node provisioning based on
               # Well-Known Labels and cloud-specific settings. These can include instance types, zones, computer architecture,
               # and capacity type (such as AWS spot or on-demand).

--- a/src/README.md
+++ b/src/README.md
@@ -24,7 +24,6 @@ Not supported:
     cluster.
   - `amiSelectorTerms`. Such terms override the `amiFamily` setting, which is the only AMI selection supported by this
     component.
-  - `instanceStorePolicy`
   - `associatePublicIPAddress`
 ## Usage
 

--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -62,6 +62,9 @@ resource "kubernetes_manifest" "ec2_node_class" {
       },
       each.value.ami_family == null ? {} : {
         amiFamily = each.value.ami_family
+      },
+      each.value.instance_store_policy == null ? {} : {
+        instanceStorePolicy = each.value.instance_store_policy
     })
   }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -262,4 +262,12 @@ variable "node_pools" {
   }))
   description = "Configuration for node pools. See code for details."
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for _, np in var.node_pools :
+      np.instance_store_policy == null || np.instance_store_policy == "RAID0"
+    ])
+    error_message = "Each node_pools[*].instance_store_policy must be null or \"RAID0\" (the only value supported by the EC2NodeClass)."
+  }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -173,6 +173,12 @@ variable "node_pools" {
     # ami_family dictates the default bootstrapping logic.
     # It is only required if you do not specify amiSelectorTerms.alias
     ami_family = optional(string, null)
+    # instanceStorePolicy controls how local NVMe instance-store volumes are used.
+    # Set to "RAID0" to format and mount them as the underlying filesystem for the
+    # kubelet and containerd (node allocatable ephemeral-storage then becomes the
+    # total instance-store size). Leave null to ignore instance-store volumes.
+    # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
+    instance_store_policy = optional(string, null)
     # Selectors for the AMI used by Karpenter provisioner when provisioning nodes.
     # Usually use { alias = "<family>@latest" } but version can be pinned instead of "latest".
     # Based on the ami_selector_terms, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)


### PR DESCRIPTION
## what

- Add an optional `instance_store_policy` field to the `node_pools` schema, passed through to the generated `EC2NodeClass` `spec.instanceStorePolicy` (mirrors how `ami_family` is wired into the `spec` merge).
- Remove `instanceStorePolicy` from the "Not supported" list in the README.

## why

[`instanceStorePolicy: RAID0`](https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy) formats and mounts a node's local NVMe instance-store volumes as the underlying filesystem for the kubelet and containerd, so pod ephemeral-storage (image layers, `emptyDir`, scratch) lands on local NVMe instead of the EBS root. This is valuable for ephemeral, IO-heavy workloads (e.g. CI runners) that otherwise saturate the gp3 root volume's throughput. The field is currently listed as unsupported, forcing consumers to fork.

## references

- Defaults to `null` (instance-store ignored) — existing behaviour is unchanged.
- AMI families AL2 / AL2023 / Bottlerocket configure RAID0 automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Karpenter NodePool/NodeClass local NVMe instance storage via `instanceStorePolicy`, with validation allowing only `RAID0` (or leaving it unset).

* **Documentation**
  * Updated “Not supported” feature limitations by removing `instanceStorePolicy` and adding `associatePublicIPAddress`.
  * Added a new “Using local NVMe instance storage” guide, including configuration examples and expected ephemeral `ephemeral-storage` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->