### PR TITLE
feat: add cpuOptions.nestedVirtualization to EC2NodeClass

### DIFF
--- a/src/ec2-node-class.tf
+++ b/src/ec2-node-class.tf
@@ -65,6 +65,13 @@ resource "kubernetes_manifest" "ec2_node_class" {
       },
       each.value.instance_store_policy == null ? {} : {
         instanceStorePolicy = each.value.instance_store_policy
+      },
+      # Strip null subfields so a cpu_options object with only some fields set
+      # does not leave nulls in the manifest and cause a perpetual plan diff.
+      each.value.cpu_options == null ? {} : {
+        cpuOptions = { for k, v in {
+          nestedVirtualization = each.value.cpu_options.nested_virtualization
+        } : k => v if v != null }
     })
   }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -179,6 +179,15 @@ variable "node_pools" {
     # total instance-store size). Leave null to ignore instance-store volumes.
     # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
     instance_store_policy = optional(string, null)
+    # cpuOptions configures instance CPU features at launch. Currently only
+    # nested_virtualization is supported: set to "enabled" to launch instances
+    # with nested virtualization turned on. When enabled, Karpenter filters to
+    # instance types reporting "nested-virtualization" in
+    # ProcessorInfo.SupportedFeatures. Requires Karpenter >= v1.13.0.
+    # https://karpenter.sh/docs/concepts/nodeclasses/#speccpuoptions
+    cpu_options = optional(object({
+      nested_virtualization = optional(string)
+    }), null)
     # Selectors for the AMI used by Karpenter provisioner when provisioning nodes.
     # Usually use { alias = "<family>@latest" } but version can be pinned instead of "latest".
     # Based on the ami_selector_terms, Karpenter will automatically query for the appropriate EKS optimized AMI via AWS Systems Manager (SSM)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -180,9 +180,10 @@ variable "node_pools" {
     # https://karpenter.sh/docs/concepts/nodeclasses/#specinstancestorepolicy
     instance_store_policy = optional(string, null)
     # cpuOptions configures instance CPU features at launch. Currently only
-    # nested_virtualization is supported: set to "enabled" to launch instances
-    # with nested virtualization turned on. When enabled, Karpenter filters to
-    # instance types reporting "nested-virtualization" in
+    # nested_virtualization is supported: "enabled" or "disabled" (validated
+    # below). Set it to "enabled" to launch instances with nested
+    # virtualization turned on. When enabled, Karpenter filters to instance
+    # types reporting "nested-virtualization" in
     # ProcessorInfo.SupportedFeatures. Requires Karpenter >= v1.13.0.
     # https://karpenter.sh/docs/concepts/nodeclasses/#speccpuoptions
     cpu_options = optional(object({
@@ -278,5 +279,14 @@ variable "node_pools" {
       np.instance_store_policy == null || np.instance_store_policy == "RAID0"
     ])
     error_message = "Each node_pools[*].instance_store_policy must be null or \"RAID0\" (the only value supported by the EC2NodeClass)."
+  }
+
+  validation {
+    condition = alltrue([
+      for _, np in var.node_pools :
+      np.cpu_options == null || np.cpu_options.nested_virtualization == null ||
+      contains(["enabled", "disabled"], np.cpu_options.nested_virtualization)
+    ])
+    error_message = "Each node_pools[*].cpu_options.nested_virtualization must be null, \"enabled\", or \"disabled\"."
   }
 }


### PR DESCRIPTION
## what

- Adds an optional `cpu_options` field to the `node_pools` object.
- Renders `spec.cpuOptions` on the self-managed EC2NodeClass, mirroring the existing `instanceStorePolicy` passthrough. Null subfields are stripped so a `cpu_options` object with only some fields set doesn't leave nulls in the manifest and cause a perpetual plan diff.

## why

Karpenter **v1.13.0** added `EC2NodeClass.spec.cpuOptions.nestedVirtualization` (`enabled`/`disabled`). It lets a NodePool launch instances with nested virtualization turned on — e.g. to run KVM/QEMU inside CI runners — without maintaining an instance-family allowlist. When enabled, Karpenter filters to instance types reporting `nested-virtualization` in `ProcessorInfo.SupportedFeatures`.

The component currently has no way to set it, so users on nested-virt workloads have to fork/patch this module.

## usage

```yaml
node_pools:
  kvm-builder:
    cpu_options:
      nested_virtualization: "enabled"
    # ...
```

## references

- Karpenter feature: aws/karpenter-provider-aws#8966 (EC2NodeClass field, merged in v1.13.0)
- Field is additive/optional; omitted entirely from the manifest when `cpu_options` is null, so it's a no-op for existing configs.

## notes

- `terraform fmt` clean.
- Follows the same shape as the `instance_store_policy` passthrough already in `src/`.
- The `## Inputs` table in `README.md` is terraform-docs-generated and currently already trails `src/` (it predates `instance_store_policy`); happy to run `make readme` in this PR if you'd prefer the regeneration bundled here rather than via the usual readme automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CPU configuration for node pools, including nested virtualization settings.

* **Bug Fixes**
  * Fixed repeated infrastructure diffs by omitting null/empty CPU-related subfields from the generated EC2 node class manifest.
  * Improved nested virtualization handling to only include it when explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->